### PR TITLE
Add support for local setting of the annotate-file.

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -627,7 +627,9 @@ an overlay and it's annotation."
 
 (defun annotate-load-annotation-data ()
   "Read and return saved annotations."
+  (setq local-annotate-file annotate-file)
   (with-temp-buffer
+    (setq-local annotate-file local-annotate-file)
     (when (file-exists-p annotate-file)
       (insert-file-contents annotate-file))
     (goto-char (point-max))

--- a/annotate.el
+++ b/annotate.el
@@ -627,15 +627,16 @@ an overlay and it's annotation."
 
 (defun annotate-load-annotation-data ()
   "Read and return saved annotations."
-  (setq local-annotate-file annotate-file)
-  (with-temp-buffer
-    (setq-local annotate-file local-annotate-file)
-    (when (file-exists-p annotate-file)
-      (insert-file-contents annotate-file))
-    (goto-char (point-max))
-    (cond ((= (point) 1) nil)
-          (t (goto-char (point-min))
-             (read (current-buffer))))))
+  ;; use the buffer-local value
+  ;; (the global value was possibly overwritten)
+  (let ((local-annotate-file annotate-file))
+    (with-temp-buffer
+      (when (file-exists-p local-annotate-file)
+	(insert-file-contents local-annotate-file))
+      (goto-char (point-max))
+      (cond ((= (point) 1) nil)
+	    (t (goto-char (point-min))
+	       (read (current-buffer)))))))
 
 (defun annotate-dump-annotation-data (data)
   "Save `data` into annotation file."


### PR DESCRIPTION
Hi @bastibe !

Thanks for this neat package. I'm using it a lot to make notes in org mode files and so far it works pretty great.

However, I like to keep my "projects" (mostly org mode files with related source code in their own directory) separated. Therefore, I tried setting `annotate-file` as a [file variable](https://www.gnu.org/software/emacs/manual/html_node/emacs/Specifying-File-Variables.html#Specifying-File-Variables). With the original implementation of `(annotate-load-annotation-data)` this doesn't work as you are creating a temporary buffer in which `annotate-file` still contains the global value (e.g. `~/.annotations`). Hence, I made a small change in your code rather soon after I had started using the package some months ago. As I'm not very familiar with Elisp I am not sure whether this is a proper solution - most probably there are better ways.

Anyways, I thought this might be a good opportunity to send my first pull request... :-) If I broke any convention, please let me know...

Do you think this could make sense - or am I getting something fundamentally wrong here?

Cheers

Matthias
