### PR TITLE
use `locate-user-emacs-file` to specify default save file

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -68,7 +68,7 @@
 (define-key annotate-mode-map (kbd "C-c ]") 'annotate-next-annotation)
 (define-key annotate-mode-map (kbd "C-c [") 'annotate-previous-annotation)
 
-(defcustom annotate-file "~/.annotations"
+(defcustom annotate-file (locate-user-emacs-file "annotations" ".annotations")
   "File where annotations are stored."
   :type 'file
   :group 'annotate)


### PR DESCRIPTION
Hi! This package is awesome!
I found small issue as Elisp package, I fix it.

---
It is recommended that Elisp packages save files in user-emacs-directory. The default value for it is `~/.emacs.d/`, and it has been changed by the user,
`locate-user-emacs-file` is returns path in consideration of the change.

And `locate-user-emacs-file` returns previous path if file exist in HOME, this change is not destructive.

cf: http://emacs.rubikitch.com/new-files/