### PR TITLE
added file checksum in annotation metadata

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -291,8 +291,8 @@ major mode."
      (string-width (annotate-actual-comment-end))))
 
 (defun annotate-wrap-in-comment (&rest strings)
-  "Put comment  markers at  the start and  (if does  makes sense)
-ends  of   a  string.   See:   annotate-actual-comment-start  and
+  "Put comment  markers at  the start and  (if it  makes sense)
+end  of   a  string.   See:   annotate-actual-comment-start  and
 annotate-actual-comment-end"
   (apply #'concat (append (list (annotate-actual-comment-start))
                           strings
@@ -731,10 +731,14 @@ an overlay and it's annotation."
   (format "-%i,%i +%i,%i" start-line diff-size start-line diff-size)))
 
 (defun annotate-checksum-from-dump (record)
+  "Get the checksum field from  an annotation list loaded from a
+file."
   (and (> (length record) 2)
        (nth 2 record)))
 
 (defun annotate-annotations-from-dump (record)
+  "Get the annotations field from  an annotation list loaded from a
+file."
   (nth 1 record))
 
 (defun annotate-load-annotation-old-format ()

--- a/annotate.el
+++ b/annotate.el
@@ -126,7 +126,7 @@ less than this size (in characters)"
           "from the last time the annotations were saved.\n"
           "Chances are that they will not be displayed correctly")
   "The message to  warn the user that file has  been modified and
-  annototatnions position could be outdated")
+  annotations positions could be outdated")
 
 (defcustom annotate-blacklist-major-mode '(org-mode)
   "Prevent  loading of  annotate-mode  When  the visited  file's
@@ -135,6 +135,8 @@ major mode is a member of this list (space separated entries)."
   :group 'annotate)
 
 (defun annotate-initialize-maybe ()
+  "Initialize annotate mode only if buffer's major mode is not in the blacklist (see:
+'annotate-blacklist-major-mode'"
   (let ((annotate-allowed-p (with-current-buffer (current-buffer)
                               (not (cl-member major-mode annotate-blacklist-major-mode)))))
     (cond
@@ -147,12 +149,16 @@ major mode is a member of this list (space separated entries)."
      (annotate-shutdown)))))
 
 (cl-defun annotate-buffer-checksum (&optional (object (current-buffer)))
+  "Calculate  an   hash  for   the  buffer  'object',   skip  the
+  calculation     if     the     buffer    is     bigger     than
+  'annotate-maximum-size-checksum' (units are character)."
   (if (< (buffer-size)
          annotate-maximum-size-checksum)
       (md5 object)
     nil))
 
 (cl-defmacro annotate-with-inhibit-modification-hooks (&rest body)
+  "Wrap 'body' in a block with modification-hooks inhibited."
   `(unwind-protect
        (progn
          (setf inhibit-modification-hooks t)
@@ -180,11 +186,13 @@ major mode is a member of this list (space separated entries)."
                                   (1 (annotate--change-guard))))))
 
 (defun annotate-overlay-filled-p (overlay)
+  "Does this overlay contains an 'annotation' property?"
   (and overlay
        (overlayp overlay)
        (overlay-get overlay 'annotation)))
 
 (defun annotationp (overlay)
+  "Is 'overlay' an annotation?"
   (annotate-overlay-filled-p overlay))
 
 (defun annotate-annotate ()

--- a/annotate.el
+++ b/annotate.el
@@ -710,7 +710,8 @@ an overlay and it's annotation."
   (format "-%i,%i +%i,%i" start-line diff-size start-line diff-size)))
 
 (defun annotate-checksum-from-dump (record)
-  (nth 2 record))
+  (and (> (length record) 2)
+       (nth 2 record)))
 
 (defun annotate-annotations-from-dump (record)
   (nth 1 record))

--- a/annotate.el
+++ b/annotate.el
@@ -116,20 +116,20 @@
   :group 'annotate)
 
 (defcustom annotate-maximum-size-checksum 5000000
-  "Calculate checksum of  the current buffer only if  the size is
+  "Calculate checksum of the current buffer only if the size is
 less than this size (in characters)"
-  :type  'integer
+  :type 'integer
   :group 'annotate)
 
 (defconst annotate-warn-file-changed-control-string
   (concat "The file '%s' has changed on disk "
           "from the last time the annotations were saved.\n"
           "Chances are that they will not be displayed correctly")
-  "The message to  warn the user that file has  been modified and
+  "The message to warn the user that file has been modified and
   annotations positions could be outdated")
 
 (defcustom annotate-blacklist-major-mode '(org-mode)
-  "Prevent  loading of  annotate-mode  When  the visited  file's
+  "Prevent loading of annotate-mode When the visited file's
 major mode is a member of this list (space separated entries)."
   :type  '(repeat symbol)
   :group 'annotate)
@@ -149,8 +149,8 @@ major mode is a member of this list (space separated entries)."
      (annotate-shutdown)))))
 
 (cl-defun annotate-buffer-checksum (&optional (object (current-buffer)))
-  "Calculate  an   hash  for   the  buffer  'object',   skip  the
-  calculation     if     the     buffer    is     bigger     than
+  "Calculate an hash for the buffer  'object', skip the
+  calculation if the buffer is bigger than
   'annotate-maximum-size-checksum' (units are character)."
   (if (< (buffer-size)
          annotate-maximum-size-checksum)
@@ -274,13 +274,13 @@ major mode is a member of this list (space separated entries)."
         (message "Annotations saved."))))
 
 (defun annotate-actual-comment-start ()
-  "String for  comment start  related to current  buffer's major
+  "String for comment start related to current buffer's major
 mode."
   (or comment-start
       annotate-fallback-comment))
 
 (defun annotate-actual-comment-end ()
-  "String for comment  ends, if any, related  to current buffer's
+  "String for comment ends, if any, related to current buffer's
 major mode."
   (or comment-end
       ""))
@@ -291,8 +291,8 @@ major mode."
      (string-width (annotate-actual-comment-end))))
 
 (defun annotate-wrap-in-comment (&rest strings)
-  "Put comment  markers at  the start and  (if it  makes sense)
-end  of   a  string.   See:   annotate-actual-comment-start  and
+  "Put comment markers at the start and  (if it makes sense)
+end of a string. See: annotate-actual-comment-start and
 annotate-actual-comment-end"
   (apply #'concat (append (list (annotate-actual-comment-start))
                           strings
@@ -731,13 +731,13 @@ an overlay and it's annotation."
   (format "-%i,%i +%i,%i" start-line diff-size start-line diff-size)))
 
 (defun annotate-checksum-from-dump (record)
-  "Get the checksum field from  an annotation list loaded from a
+  "Get the checksum field from an annotation list loaded from a
 file."
   (and (> (length record) 2)
        (nth 2 record)))
 
 (defun annotate-annotations-from-dump (record)
-  "Get the annotations field from  an annotation list loaded from a
+  "Get the annotations field from an annotation list loaded from a
 file."
   (nth 1 record))
 

--- a/annotate.el
+++ b/annotate.el
@@ -123,9 +123,9 @@ less than this size (in characters)"
 
 (defconst annotate-warn-file-changed-control-string
   (concat "The file '%s' has changed on disk "
-          "from the last time the annotations was saved.\n"
+          "from the last time the annotations were saved.\n"
           "Chances are that they will not be displayed correctly")
-  "The  message to  warn user  that  file has  been modified  and
+  "The message to  warn the user that file has  been modified and
   annototatnions position could be outdated")
 
 (defcustom annotate-blacklist-major-mode '(org-mode)

--- a/annotate.el
+++ b/annotate.el
@@ -62,7 +62,7 @@
   :lighter " Ann"
   :keymap (make-sparse-keymap)
   :group 'annotate
-  :after-hook (annotate-after-hook))
+  :after-hook (annotate-initialize-maybe))
 
 (define-key annotate-mode-map (kbd "C-c C-a") 'annotate-annotate)
 
@@ -134,7 +134,7 @@ major mode is a member of this list (space separated entries)."
   :type  '(repeat symbol)
   :group 'annotate)
 
-(defun annotate-after-hook ()
+(defun annotate-initialize-maybe ()
   (let ((annotate-allowed-p (with-current-buffer (current-buffer)
                               (not (cl-member major-mode annotate-blacklist-major-mode)))))
     (cond

--- a/annotate.el
+++ b/annotate.el
@@ -129,7 +129,7 @@ less than this size (in characters)"
   annototatnions position could be outdated")
 
 (defcustom annotate-blacklist-major-mode '(org-mode)
-  "Prevent  loading of  annotated-mode  When  the visited  file's
+  "Prevent  loading of  annotate-mode  When  the visited  file's
 major mode is a member of this list (space separated entries)."
   :type  '(repeat symbol)
   :group 'annotate)

--- a/annotate.el
+++ b/annotate.el
@@ -115,12 +115,6 @@
   :type 'string
   :group 'annotate)
 
-(defcustom annotate-maximum-size-checksum 5000000
-  "Calculate checksum of the current buffer only if the size is
-less than this size (in characters)"
-  :type 'integer
-  :group 'annotate)
-
 (defconst annotate-warn-file-changed-control-string
   (concat "The file '%s' has changed on disk "
           "from the last time the annotations were saved.\n"
@@ -149,13 +143,8 @@ major mode is a member of this list (space separated entries)."
      (annotate-shutdown)))))
 
 (cl-defun annotate-buffer-checksum (&optional (object (current-buffer)))
-  "Calculate an hash for the buffer  'object', skip the
-  calculation if the buffer is bigger than
-  'annotate-maximum-size-checksum' (units are character)."
-  (if (< (buffer-size)
-         annotate-maximum-size-checksum)
-      (md5 object)
-    nil))
+  "Calculate an hash for the argument 'object'."
+  (secure-hash 'md5 object))
 
 (cl-defmacro annotate-with-inhibit-modification-hooks (&rest body)
   "Wrap 'body' in a block with modification-hooks inhibited."


### PR DESCRIPTION
Hello!

With these commits i tried to address #6. I have added am md5 hash to each annotated file. When  annotate minor mode is loaded a check between the hash stored in the metadata (`.emacs.d/annotations`) and the current buffer is performed. If the two checksum are not equals a warning text is displayed.
When a file is saved an md5 sum is calculated for current buffer and stored in the metadata file.

Also added a 'blacklist' of major modes that prevents annotate to be loaded.

Hope i understood #6 correctly, though! :-)

Please consider merging.

bye!
C.