### PR TITLE
- added an annotation summary window

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -808,7 +808,7 @@ essentially what you get from:
            (modified-p           (buffer-modified-p)))
       (if (old-format-p annotation-dump)
           (annotate-load-annotation-old-format)
-        (when (and (not (old-format-p annotations))
+        (when (and (not (old-format-p annotation-dump))
                    old-checksum
                    new-checksum
                    (not (string= old-checksum new-checksum)))

--- a/annotate.el
+++ b/annotate.el
@@ -130,7 +130,7 @@ major mode is a member of this list (space separated entries)."
   "The message to warn the user that file has been modified and
   annotations positions could be outdated")
 
-(defconst annotate-summary-list-prefix "  - "
+(defconst annotate-summary-list-prefix "    "
   "The string used as prefix for each text annotation item in summary window")
 
 (defconst annotate-summary-list-prefix-file "* File: "

--- a/annotate.el
+++ b/annotate.el
@@ -991,11 +991,11 @@ essentially what you get from:
      "*annotations*" nil nil
      (display-buffer "*annotations*")
      (select-window (get-buffer-window "*annotations*" t))
+     (outline-mode)
      (use-local-map nil)
      (local-set-key "q" (lambda ()
                           (interactive)
                           (kill-buffer "*annotations*")))
-     (outline-mode)
      (let ((dump (annotate-load-annotation-data)))
        (dolist (annotation dump)
          (let ((all-annotations (annotate-annotations-from-dump annotation))

--- a/annotate.el
+++ b/annotate.el
@@ -554,6 +554,20 @@ to 'maximum-width'."
                                         (join-until-width (cl-rest words) new-word)
                                       (make-annotate-group :words      words
                                                            :start-word (or word next-word)))))))
+              (split-position (text column-max-width)
+                              (let ((character-width (length       text))
+                                    (column-width    (string-width text)))
+                                (if (= character-width column-width)
+                                    column-max-width
+                                  (let* ((res    0)
+                                         (so-far ""))
+                                    (cl-loop for i from 0 below column-max-width
+                                             until (>= (string-width so-far)
+                                                       column-max-width)
+                                             do
+                                             (setf so-far (concat so-far (string (elt text i))))
+                                             (setf res i))
+                                    res))))
               (%group (words so-far)
                       (cond
                        ((null words)
@@ -570,16 +584,17 @@ to 'maximum-width'."
                                   (append (list potential-start)
                                           so-far))))
                        (t
-                        (let* ((word       (cl-first words))
-                               (rest-words (cl-rest words))
-                               (prefix     (cl-subseq word 0 maximum-width))
-                               (next-word  (if rest-words
-                                               (cl-first rest-words)
-                                             ""))
-                               (raw-suffix (cl-subseq word maximum-width))
-                               (suffix     (if rest-words
-                                               (concat raw-suffix " " next-word)
-                                             raw-suffix)))
+                        (let* ((word           (cl-first words))
+                               (rest-words     (cl-rest words))
+                               (split-position (split-position word maximum-width))
+                               (prefix         (cl-subseq word 0 split-position))
+                               (next-word      (if rest-words
+                                                   (cl-first rest-words)
+                                                 ""))
+                               (raw-suffix     (cl-subseq word split-position))
+                               (suffix         (if rest-words
+                                                   (concat raw-suffix " " next-word)
+                                                 raw-suffix)))
                           (%group (append (list suffix)
                                           (cl-rest rest-words))
                                   (append (list prefix)

--- a/annotate.el
+++ b/annotate.el
@@ -749,7 +749,7 @@ essentially what you get from:
 (annotate-annotations-from-dump (annotate-load-annotations))). "
   (cl-first annotation))
 
-(defun annotate-text-annotation-dump (annotation)
+(defun annotate-text-of-annotation (annotation)
   "Get the text of an annotation. The arg 'annotation' must be a single
 annotation field got from a file dump of all annotated buffers,
 essentially what you get from:
@@ -956,7 +956,7 @@ essentially what you get from:
                (insert (format "%s\n\n" filename))
                (dolist (annotation-field all-annotations)
                  (let ((button-text (format "%s"
-                                            (annotate-text-annotation-dump annotation-field))))
+                                            (annotate-text-of-annotation annotation-field))))
                    (insert "- ")
                    (insert-button (propertize (ellipsize button-text) 'face 'bold)
                                   'file   filename

--- a/annotate.el
+++ b/annotate.el
@@ -927,7 +927,7 @@ essentially what you get from:
   'help-echo "Click to show")
 
 (defun annotate-summary-button-pressed (button)
-  "Callback called when a sunmmary button is activated"
+  "Callback called when an annotate-summary-button is activated"
   (let ((buffer (find-file-other-window (button-get button 'file))))
     (with-current-buffer buffer
       (goto-char (button-get button 'go-to)))))

--- a/annotate.el
+++ b/annotate.el
@@ -980,7 +980,7 @@ essentially what you get from:
                                                   'action 'annotate-summary-button-pressed
                                                   'type   'annotate-summary-button)
                                    (insert "\n\n"))
-              (build-snippet ()
+              (build-snippet (filename annotation-begin annotation-end)
                              (with-temp-buffer
                                (insert-file-contents filename
                                                      nil
@@ -1008,7 +1008,9 @@ essentially what you get from:
                                                 (annotate-text-of-annotation annotation-field)))
                       (annotation-begin (annotate-beginning-of-annotation annotation-field))
                       (annotation-end   (annotate-ending-of-annotation    annotation-field))
-                      (snippet-text     (build-snippet)))
+                      (snippet-text     (build-snippet filename
+                                                       annotation-begin
+                                                       annotation-end)))
                  (insert-item-summary snippet-text button-text))))))))))
 
 (provide 'annotate)

--- a/annotate.el
+++ b/annotate.el
@@ -130,10 +130,11 @@ major mode is a member of this list (space separated entries)."
   :type  '(repeat symbol)
   :group 'annotate)
 
-(defcustom annotate-summary-link-max-width  64
-  "Cut the link text in a summary windows to this maximum size (in character)"
-  :type  'number
-  :group 'annotate)
+(defconst annotate-summary-list-prefix "- "
+  "The string used as prefix for each text annotation item in summary window")
+
+(defconst annotate-ellipse-text-marker "..."
+  "The string used when a string is truncated with an ellipse")
 
 (defun annotate-initialize-maybe ()
   "Initialize annotate mode only if buffer's major mode is not in the blacklist (see:
@@ -936,11 +937,18 @@ essentially what you get from:
   "Show a summary of all the annotations in a temp buffer"
   (interactive)
   (cl-labels ((ellipsize (text)
+                         (let ((prefix-length  (string-width annotate-summary-list-prefix))
+                               (ellipse-length (string-width annotate-ellipse-text-marker)))
                          (if (> (string-width text)
-                                annotate-summary-link-max-width)
-                             (concat (subseq text 0 (- annotate-summary-link-max-width 3))
-                                     "...")
-                           text)))
+                                (+ (window-body-width)
+                                   prefix-length
+                                   ellipse-length))
+                             (concat (subseq text 0
+                                             (- (window-body-width)
+                                                prefix-length
+                                                ellipse-length))
+                                     annotate-ellipse-text-marker)
+                             text))))
     (with-temp-buffer-window
      "*annotations*" nil nil
      (with-current-buffer "*annotations*"

--- a/annotate.el
+++ b/annotate.el
@@ -142,6 +142,10 @@ major mode is a member of this list (space separated entries)."
 (defconst annotate-ellipse-text-marker "..."
   "The string used when a string is truncated with an ellipse")
 
+(defun annotate-annotations-exist-p ()
+  (find-if 'annotationp
+           (overlays-in 0 (buffer-size))))
+
 (defun annotate-initialize-maybe ()
   "Initialize annotate mode only if buffer's major mode is not in the blacklist (see:
 'annotate-blacklist-major-mode'"
@@ -151,10 +155,11 @@ major mode is a member of this list (space separated entries)."
      ((not annotate-allowed-p)
       (annotate-shutdown)
       (setq annotate-mode nil))
-    (annotate-mode
-     (annotate-initialize))
-    (t
-     (annotate-shutdown)))))
+     (annotate-mode
+      (when (not (annotate-annotations-exist-p))
+        (annotate-initialize)))
+     (t
+      (annotate-shutdown)))))
 
 (cl-defun annotate-buffer-checksum (&optional (object (current-buffer)))
   "Calculate an hash for the argument 'object'."

--- a/annotate.el
+++ b/annotate.el
@@ -742,7 +742,7 @@ file."
 file."
   (cl-first record))
 
-(defun annotate-start-annotation-dump (annotation)
+(defun annotate-beginning-of-annotation (annotation)
   "Get the starting point of an annotation. The arg 'annotation' must be a single
 annotation field got from a file dump of all annotated buffers,
 essentially what you get from:
@@ -960,7 +960,7 @@ essentially what you get from:
                    (insert "- ")
                    (insert-button (propertize (ellipsize button-text) 'face 'bold)
                                   'file   filename
-                                  'go-to  (annotate-start-annotation-dump annotation-field)
+                                  'go-to  (annotate-beginning-of-annotation annotation-field)
                                   'action 'annotate-summary-button-pressed
                                   'type   'annotate-summary-button)
                    (insert "\n\n")))))))))))


### PR DESCRIPTION
  the  command   'annotate-show-annotation-summary'  popup   a  window
  containing a  textual description  of the  annotations found  in the
  annotation file (like ~/.emacs/annotations) with the format:

      -------

  /path/of/an/annotated/file

  - annotation text
  - annotation text

  /another/path/of/an/annotated/file

  - annotation text

  ...

      -------

Each annotation text is a link  that, if activated (via a mouse click,
for  example),  opens a  buffer  showing  the  annotated file  at  the
position  of  the  annotated  text (the  underlined  one)  linked  to
annotation.

Bye!!
C.