### PR TITLE
Preventing loss of undo list

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -143,8 +143,8 @@ major mode is a member of this list (space separated entries)."
   "The string used when a string is truncated with an ellipse")
 
 (defun annotate-annotations-exist-p ()
-  (find-if 'annotationp
-           (overlays-in 0 (buffer-size))))
+  (cl-find-if 'annotationp
+              (overlays-in 0 (buffer-size))))
 
 (defun annotate-initialize-maybe ()
   "Initialize annotate mode only if buffer's major mode is not in the blacklist (see:
@@ -836,7 +836,7 @@ essentially what you get from:
                    old-checksum
                    new-checksum
                    (not (string= old-checksum new-checksum)))
-          (lwarn "annotate-mode"
+          (lwarn '(annotate-mode)
                  :warning
                  annotate-warn-file-changed-control-string
                  filename))

--- a/annotate.el
+++ b/annotate.el
@@ -700,18 +700,22 @@ to 'maximum-width'."
   "Cleans up annotation properties associated with a region."
   ;; inhibit infinite loop
   (setq inhibit-modification-hooks t)
-  ;; inhibit property removal to the undo list
-  (buffer-disable-undo)
-  (save-excursion
-    (goto-char end)
-    ;; go to the EOL where the
-    ;; annotated newline used to be
-    (end-of-line)
-    ;; strip dangling display property
-    (remove-text-properties
-     (point) (1+ (point)) '(display nil)))
-  (buffer-enable-undo)
-  (setq inhibit-modification-hooks nil))
+  ;; copy undo list
+  (let ((saved-undo-list (copy-tree buffer-undo-list t)))
+    ;; inhibit property removal to the undo list (and empty it too)
+    (buffer-disable-undo)
+    (save-excursion
+      (goto-char end)
+      ;; go to the EOL where the
+      ;; annotated newline used to be
+      (end-of-line)
+      ;; strip dangling display property
+      (remove-text-properties
+       (point) (1+ (point)) '(display nil)))
+    ;; restore undo list
+    (setf buffer-undo-list saved-undo-list)
+    (buffer-enable-undo)
+    (setq inhibit-modification-hooks nil)))
 
 (defun annotate--change-guard ()
   "Returns a `facespec` with an `insert-behind-hooks` property


### PR DESCRIPTION
  According  to the  documentation  the function  'uffer-disable-undo'
  discards all  the already registered buffer's  modification. This is
  undesiderable, to  prevent this  the old buffer  list is  copied and
  restored in 'annotate--remove-annotation-property'.