### PR TITLE
- added a secondary  color for highlight and annotation  text

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -184,22 +184,31 @@ major mode is a member of this list (space separated entries)."
      (setf inhibit-modification-hooks t)))
 
 (defun annotate-end-of-line-pos ()
+ "Get the position of the end of line and rewind the point's
+postion (so that it is unchanged after this function is called)."
   (save-excursion
     (end-of-line)
     (point)))
 
 (defun annotate-beginning-of-line-pos ()
+  "Get the position of the beginning of line and rewind the point's
+postion (so that it is unchanged after this function is called)."
   (save-excursion
     (beginning-of-line)
     (point)))
 
 (defun annotate-before-change-fn (a b)
+ "This function is added to 'before-change-functions' hook and
+it is called any time the buffer content is changed (so, for
+example, text is added or deleted). In particular, it will
+rearrange the overlays bounds when an annotated text is
+modified (for example a newline is inserted)."
   (annotate-with-inhibit-modification-hooks
    (save-excursion
-     (let* ((bol      (annotate-beginning-of-line-pos))
-            (eol      (annotate-end-of-line-pos))
-            (ov       (cl-remove-if-not 'annotationp
-                                        (overlays-in bol eol))))
+     (let* ((bol (annotate-beginning-of-line-pos))
+            (eol (annotate-end-of-line-pos))
+            (ov  (cl-remove-if-not 'annotationp
+                                   (overlays-in bol eol))))
        (dolist (overlay ov)
          (annotate--remove-annotation-property (overlay-start overlay)
                                                (overlay-end   overlay))

--- a/annotate.el
+++ b/annotate.el
@@ -183,12 +183,12 @@ major mode is a member of this list (space separated entries)."
          ,@body)
      (setf inhibit-modification-hooks t)))
 
-(defun annotate-calc-end-of-line ()
+(defun annotate-end-of-line-pos ()
   (save-excursion
     (end-of-line)
     (point)))
 
-(defun annotate-calc-beginning-of-line ()
+(defun annotate-beginning-of-line-pos ()
   (save-excursion
     (beginning-of-line)
     (point)))
@@ -196,8 +196,8 @@ major mode is a member of this list (space separated entries)."
 (defun annotate-before-change-fn (a b)
   (annotate-with-inhibit-modification-hooks
    (save-excursion
-     (let* ((bol      (annotate-calc-beginning-of-line))
-            (eol      (annotate-calc-end-of-line))
+     (let* ((bol      (annotate-beginning-of-line-pos))
+            (eol      (annotate-end-of-line-pos))
             (ov       (cl-remove-if-not 'annotationp
                                         (overlays-in bol eol))))
        (dolist (overlay ov)

--- a/annotate.el
+++ b/annotate.el
@@ -83,7 +83,7 @@
   :group 'annotate)
 
 (defface annotate-highlight-secondary
-  '((t (:underline "turquoise")))
+  '((t (:underline "khaki")))
   "Face for secondary annotation highlights."
   :group 'annotate)
 
@@ -93,7 +93,7 @@
   :group 'annotate)
 
 (defface annotate-annotation-secondary
-  '((t (:background "turquoise" :foreground "black")))
+  '((t (:background "khaki" :foreground "black")))
   "Face for secondary annotations."
   :group 'annotate)
 

--- a/annotate.el
+++ b/annotate.el
@@ -701,14 +701,14 @@ to 'maximum-width'."
   "Searches the line before point for annotations, and returns a
 `facespec` with the annotation in its `display` property."
   (save-excursion
-    (goto-char (1- (point))) ; we start at the start of the next line
+    (goto-char (1- (point)))  ; we start at the start of the next line
     ;; find overlays in the preceding line
-    (let ((prefix          (annotate-make-prefix)) ; white space before first annotation
-          (bol             (progn (beginning-of-line) (point)))
-          (eol             (progn (end-of-line) (point)))
-          (text            "")
-          (overlays        nil)
-          (face-type-count 1))
+    (let ((prefix             (annotate-make-prefix)) ; white spaces before first annotation
+          (bol                (progn (beginning-of-line) (point)))
+          (eol                (progn (end-of-line) (point)))
+          (text               "")
+          (overlays           nil)
+          (annotation-counter 1))
       ;; include previous line if point is at bol:
       (when (eq nil (overlays-in bol eol))
         (setq bol (1- bol)))
@@ -718,11 +718,11 @@ to 'maximum-width'."
                     (< (overlay-end x) (overlay-end y)))))
       ;; put each annotation on its own line
       (dolist (ov overlays)
-        (cl-incf face-type-count)
-        (let ((face           (if (= (cl-rem face-type-count 2) 0)
+        (cl-incf annotation-counter)
+        (let ((face           (if (= (cl-rem annotation-counter 2) 0)
                                   'annotate-annotation
                                 'annotate-annotation-secondary))
-              (face-highlight (if (= (cl-rem face-type-count 2) 0)
+              (face-highlight (if (= (cl-rem annotation-counter 2) 0)
                                   'annotate-highlight
                                 'annotate-highlight-secondary)))
           (overlay-put ov 'face face-highlight)

--- a/annotate.el
+++ b/annotate.el
@@ -185,14 +185,14 @@ major mode is a member of this list (space separated entries)."
 
 (defun annotate-end-of-line-pos ()
  "Get the position of the end of line and rewind the point's
-postion (so that it is unchanged after this function is called)."
+position (so that it is unchanged after this function is called)."
   (save-excursion
     (end-of-line)
     (point)))
 
 (defun annotate-beginning-of-line-pos ()
   "Get the position of the beginning of line and rewind the point's
-postion (so that it is unchanged after this function is called)."
+position (so that it is unchanged after this function is called)."
   (save-excursion
     (beginning-of-line)
     (point)))


### PR DESCRIPTION
The two colors are  shown in an alternate  way for annotation placed  on the
  same lines;
- fixed point position when text was added on a line with annotation box
``` text
                                       +--- you add text here...
                                       |
                                       V
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
                                     +---------+
^ but the cursor is shown here       | note    |
| instead :-(                        | note    |
|                                    | note    |
|                                    +---------+
|
|
```
- fixed annotation position when a single line (as region) is annotated.