### PR TITLE
- added features: annotate info documents.

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -154,7 +154,7 @@ major mode is a member of this list (space separated entries)."
  summary window because does not exist or is in an unsupported
  format.")
 
-(defconst annotate-valid-info-extensions
+(defconst annotate-info-valid-file-extensions
   '(".info" ".info.gz" ".gz")
  "The valid extension for files that contains info document")
 
@@ -372,7 +372,7 @@ modified (for example a newline is inserted)."
                      filename
                    nil)))
       (cl-block surrounding
-        (dolist (extension annotate-valid-info-extensions)
+        (dolist (extension annotate-info-valid-file-extensions)
           (let ((filename-maybe (concat filename extension)))
             (when (file-exists-p filename-maybe)
               (setf found filename-maybe)

--- a/annotate.el
+++ b/annotate.el
@@ -180,7 +180,7 @@ annotation as defined in the database."
   "The string used when a string is truncated with an ellipse")
 
 (defconst annotate-info-root-name "dir"
-  "The pseudofilename of info root")
+  "The pseudo-filename of info root")
 
 (defun annotate-annotations-exist-p ()
   "Does this buffer contains at least one or more annotations?"
@@ -1231,12 +1231,14 @@ The searched interval can be customized setting the variable:
            annotate-info-root-name))
 
 (defun annotate-guess-file-format (filename)
-  "Try to guess the file format."
+  "Try to guess the file format.
+Non nil if the file format is supported from 'annotate' in a more
+sophisticated way than plain text"
   (cl-labels ((file-contents ()
                              (with-temp-buffer
                                (insert-file-contents filename)
                                (buffer-string)))
-              (info-format-p ()
+              (info-format-p () ;; lot of guesswork here :(
                              (cond
                               ((annotate-info-root-dir-p filename)
                                :info)

--- a/annotate.el
+++ b/annotate.el
@@ -353,9 +353,14 @@ modified (for example a newline is inserted)."
       ;; jump to first overlay in list
       (goto-char (overlay-start (nth 0 overlays))))))
 
+(defun annotate-info-actual-filename ()
+  "The info  filename that feed  this buffer  or nil if  not this
+buffer is not on info-mode"
+  (annotate-guess-filename-for-dump Info-current-file nil))
+
 (defun annotate-actual-file-name ()
   "Get the actual file name of the current buffer"
-  (substring-no-properties (or (annotate-guess-filename-for-dump Info-current-file nil)
+  (substring-no-properties (or (annotate-info-actual-filename)
                                (buffer-file-name)
                                "")))
 

--- a/annotate.el
+++ b/annotate.el
@@ -857,24 +857,22 @@ to 'maximum-width'."
   "Cleans up annotation properties associated with a region."
   (when (> (buffer-size)
            0)
-    ;; inhibit infinite loop
-    (setq inhibit-modification-hooks t)
-    ;; copy undo list
-    (let ((saved-undo-list (copy-tree buffer-undo-list t)))
-      ;; inhibit property removal to the undo list (and empty it too)
-      (buffer-disable-undo)
-      (save-excursion
-        (goto-char end)
-        ;; go to the EOL where the
-        ;; annotated newline used to be
-        (end-of-line)
-        ;; strip dangling display property
-        (remove-text-properties
-         (point) (1+ (point)) '(display nil)))
-      ;; restore undo list
-      (setf buffer-undo-list saved-undo-list)
-      (buffer-enable-undo)
-      (setq inhibit-modification-hooks nil))))
+    (annotate-with-inhibit-modification-hooks
+     ;; copy undo list
+     (let ((saved-undo-list (copy-tree buffer-undo-list t)))
+       ;; inhibit property removal to the undo list (and empty it too)
+       (buffer-disable-undo)
+       (save-excursion
+         (goto-char end)
+         ;; go to the EOL where the
+         ;; annotated newline used to be
+         (end-of-line)
+         ;; strip dangling display property
+         (remove-text-properties
+          (point) (1+ (point)) '(display nil)))
+       ;; restore undo list
+       (setf buffer-undo-list saved-undo-list)
+       (buffer-enable-undo)))))
 
 (defun annotate--change-guard ()
   "Returns a `facespec` with an `insert-behind-hooks` property

--- a/annotate.el
+++ b/annotate.el
@@ -1262,7 +1262,12 @@ sophisticated way than plain text"
          (file-type (annotate-guess-file-format file)))
     (cond
      ((eq file-type :info)
-      (info file))
+      (with-current-buffer-window
+       "*info*" nil nil
+       (info-setup file (current-buffer))
+       (switch-to-buffer "*info*"))
+      (with-current-buffer "*info*"
+        (goto-char (button-get button 'go-to))))
      (t
       (let* ((buffer (find-file-other-window file)))
         (with-current-buffer buffer


### PR DESCRIPTION
Hello!

this is my attempt to address #48 
there are some points to investigate in my opinion, in details:

- when an info node is annotated and the user try to save the file emacs will ask a file name where dumps the info buffer and this package annotate that saved file, if just 'annnotate-save-annotation' is called the correct file is annotated, though. i am not sure this is an actual bug, this behaviour seems reasonably correct to me; please @randomwangran, can you tell us it this is the same way you used your patched version of this program?

- the function 'annotate-info-select-fn' is a bit slow it is not difficult to understand why ;-);

- on my system if i do not add the test '(when (buffer-file-name)' in the hook called before a buffer's content is changed a weird error complaining about buffer encoding pop up, i suspect there is a better way to get rid of this error but i had no better idea so far.

Bye!
C.
