### PR TITLE
- used a better regex when checking if a file is in info format.

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -1243,7 +1243,8 @@ sophisticated way than plain text"
                               (t
                                (let* ((file-contents     (file-contents))
                                       (has-info-p        (string-match "info" filename))
-                                      (has-separator-p   (string-match "" file-contents))
+                                      (has-separator-p   (string-match "\\(\\)?\\(\\)?$"
+                                                                       file-contents))
                                       (has-node-p        (string-match "Node:" file-contents)))
                                  (if (or (annotate-info-root-dir-p filename)
                                          (and has-separator-p


### PR DESCRIPTION
Hi!

According to the manual the separator for info format is a bit more complex than a simple `C-_`,  using the latter made the annotate file source looks like an info file! :D

Bye!
C.