### PR TITLE
Filter summary window results

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -1284,7 +1284,7 @@ sophisticated way than plain text"
                              (with-temp-buffer
                                (insert-file-contents filename)
                                (buffer-string)))
-              (info-format-p () ;; lot of guesswork here :(
+              (info-format-p () ; lot of guesswork here :(
                              (cond
                               ((annotate-info-root-dir-p filename)
                                :info)
@@ -1674,7 +1674,7 @@ NOT        := 'not'
              ;; NOTE := NOTE OR NOTE
              ((token-symbol-match-p 'or look-ahead)
               (annotate-summary-lexer) ; consume the 'or'
-              (let ((lhs res)  ;; the left side of this rule lhs OR rhs
+              (let ((lhs res)          ; the left side of this rule (lhs OR rhs)
                     (rhs (annotate-summary-query-parse-note filter-fn annotation :error))) ; recurse
                 (if (eq :error rhs)
                     (error "No more input after 'or'")
@@ -1692,7 +1692,7 @@ NOT        := 'not'
                 ;; and finally continue the parsing saving the results
                 ;; of applying the filter-fn function
                 (operator escaped filter-fn annotation matchp)))))
-        ;; if we are here the lexer can not fine any more tokens in the query
+        ;; if we are here the lexer can not find any more tokens in the query
         ;; just return the value of res
         res)))) ; end of (if (not (annotate-summary-query-parse-end-input-p look-ahead))
 
@@ -1724,7 +1724,7 @@ This function return the annotation of the record
   (lambda (annotation query file-filter-fn note-filter-fn)
     (let ((annotate-summary-query query) ; save the query
           (query-notes-only       nil)) ; the query for just the notes
-      (let ((next-token (annotate-summary-lexer))) ;; get file-mask
+      (let ((next-token (annotate-summary-lexer))) ; get file-mask
         ;; if there are no more tokes just return all the records
         ;; these match the empty string as in rule
         ;; EXPRESSION := epsilon

--- a/annotate.el
+++ b/annotate.el
@@ -1243,7 +1243,8 @@ sophisticated way than plain text"
                               (t
                                (let* ((file-contents     (file-contents))
                                       (has-info-p        (string-match "info" filename))
-                                      (has-separator-p   (string-match "" file-contents))
+                                      (has-separator-p   (string-match "\\(\\)?\\(\\)?$"
+                                                                       file-contents))
                                       (has-node-p        (string-match "Node:" file-contents)))
                                  (if (or (annotate-info-root-dir-p filename)
                                          (and has-separator-p


### PR DESCRIPTION
Hi!

A friend of mine gave me that idea to filter the entries shown in the summary window, i could not resist! ;-)

I quickly tested this feature and (also given it is simple), in my opinion should work. At this time the parenthesis can not be used as search text but i think this could be fixed using escape and i hope to fix that in the next days.

Essentially before a summary window is shown the user is asked for a query and the database of annotations is filtered against this query; the results ,if any, are shown in the window.

The syntax for this simple query language can be found in the docstring of ` annotate-summary-filter-db`.
The user can disable the query mechanism using customizable variable `annotate-summary-ask-query`.


Bye!
C.