### PR TITLE
Annotations on their own line

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -823,24 +823,24 @@ to 'maximum-width'."
                                          annotation-long-p)
                                         (otherwise
                                          nil)))
-                 (splitted-annotation (if position-new-line-p
-                                          (list (overlay-get ov 'annotation))
-                                        (save-match-data
-                                          (split-string (annotate-lineate (overlay-get ov
-                                                                                       'annotation)
-                                                                          (- eol bol))
-                                                        "\n"))))
-                 (annotation-stopper  (if position-new-line-p
-                                          (if (= annotation-counter
-                                                 (length overlays))
-                                              "\n"
-                                            "")
-                                        "\n")))
+                 (multiline-annotation (if position-new-line-p
+                                           (list (overlay-get ov 'annotation))
+                                         (save-match-data
+                                           (split-string (annotate-lineate (overlay-get ov
+                                                                                        'annotation)
+                                                                           (- eol bol))
+                                                         "\n"))))
+                 (annotation-stopper   (if position-new-line-p
+                                           (if (= annotation-counter
+                                                  (length overlays))
+                                               "\n"
+                                             "")
+                                         "\n")))
             (cl-incf annotation-counter)
             (overlay-put ov 'face face-highlight)
             (when position-new-line-p
               (setf prefix-first " \n"))
-            (dolist (l splitted-annotation)
+            (dolist (l multiline-annotation)
               (setq text
                     (concat text
                             prefix-first

--- a/annotate.el
+++ b/annotate.el
@@ -787,7 +787,7 @@ to 'maximum-width'."
             (prefix-rest        (make-string annotate-annotation-column ? ))
             (bol                (progn (beginning-of-line) (point)))
             (eol                (progn (end-of-line) (point)))
-            (text               "")
+            (annotation-text    "")
             (overlays           nil)
             (annotation-counter 1))
         ;; include previous line if point is at bol:
@@ -851,8 +851,8 @@ to 'maximum-width'."
             (when position-new-line-p
               (setf prefix-first " \n"))
             (dolist (l multiline-annotation)
-              (setq text
-                    (concat text
+              (setq annotation-text
+                    (concat annotation-text
                             prefix-first
                             (propertize l 'face face)
                             annotation-stopper))
@@ -861,11 +861,11 @@ to 'maximum-width'."
                   (setq prefix-first (concat prefix-first prefix-rest))
                 (setq prefix-first prefix-rest)))))
         ;; build facespec with the annotation text as display property
-        (if (string= text "")
+        (if (string= annotation-text "")
             ;; annotation has been removed: remove display prop
             (list 'face 'default 'display nil)
           ;; annotation has been changed/added: change/add display prop
-          (list 'face 'default 'display text))))))
+          (list 'face 'default 'display annotation-text))))))
 
 (defun annotate--remove-annotation-property (begin end)
   "Cleans up annotation properties associated with a region."

--- a/annotate.el
+++ b/annotate.el
@@ -826,8 +826,7 @@ to 'maximum-width'."
                                         'annotate-highlight-secondary))
                  (annotation-long-p   (> (string-width (overlay-get ov 'annotation))
                                          annotate-annotation-max-size-not-place-new-line))
-                 (position            annotate-annotation-position-policy)
-                 (position-new-line-p (cl-case position
+                 (position-new-line-p (cl-case annotate-annotation-position-policy
                                         (:new-line
                                          t)
                                         (:by-length

--- a/annotate.el
+++ b/annotate.el
@@ -155,6 +155,11 @@ database is not filtered at all."
      always on right margin
   - :by-length
     decide by text's length
+
+    if the length is more than the value of
+    `annotate-annotation-max-size-not-place-new-line' place the
+    annotation on a new line, place on the right margin
+    otherwise.
 "
   :type  'symbol
   :group 'annotate)
@@ -805,7 +810,10 @@ to 'maximum-width'."
                                   (overlays-in bol eol))
                     (lambda (x y)
                       (< (overlay-end x) (overlay-end y)))))
-        ;; put each annotation on its own line
+        ;; configure each annotation's properties  and place it on the
+        ;; the window. The actual  position of the annotation (newline
+        ;; or  right  marigin)  is  indicated  by  the  value  of  the
+        ;; variable: `annotate-annotation-position-policy'.
         (dolist (ov overlays)
           (let* ((face                (if (= (cl-rem annotation-counter 2) 0)
                                           'annotate-annotation

--- a/annotate.el
+++ b/annotate.el
@@ -780,13 +780,16 @@ to 'maximum-width'."
     (let ((newline-position (point)))
       (goto-char (1- (point))) ; we start at the start of the previous line
       ;; find overlays in the preceding line
-      (let* ((prefix-first       (annotate-make-prefix)) ; white spaces before first line of annotation
-             (prefix-rest        (make-string annotate-annotation-column ? ))
-             (bol                (progn (beginning-of-line) (point)))
-             (eol                (progn (end-of-line) (point)))
-             (text               "")
-             (overlays           nil)
-             (annotation-counter 1))
+      (let ((prefix-first       (annotate-make-prefix)) ; white spaces
+                                                        ; before first
+                                                        ; line of
+                                                        ; annotation
+            (prefix-rest        (make-string annotate-annotation-column ? ))
+            (bol                (progn (beginning-of-line) (point)))
+            (eol                (progn (end-of-line) (point)))
+            (text               "")
+            (overlays           nil)
+            (annotation-counter 1))
         ;; include previous line if point is at bol:
         (when (null (overlays-in bol eol))
           (setq bol (1- bol)))


### PR DESCRIPTION
Hi!

with this PR i try to add the feature as described in #20 

There is a variable `annotate-annotation-position-policy` that can specify the policy to set the annotation position: on a new line, on the margin or on a new line only when the annotation's size exceed the value of `annotate-annotation-max-size-not-place-new-line`.

I strongly feel that the name of the above variables can be changed in something better! :)

Bye!
C.