### PR TITLE
Fixed annotation picking in 'annotate-annotate'

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,7 +10,7 @@
           positioning.
           See the local function
           'maybe-force-newline-policy' in 'annotate-create-annotation'.
-        - choosen the window that contains the current buffer when resizing the annotations
+        - chosen the window that contains the current buffer when resizing the annotations
           see variable 'current-window' in 'annotate-lineate';
         - redraw buffer if one of its annotations is deleted
           operating from the summary window.
@@ -50,7 +50,7 @@
         - when re-flowing annotation the window width was calculated always
         for the current buffer (the one with the focus).
 
-2020-04-06 Bastian Bechtold, cage
+2020-03-06 Bastian Bechtold, cage
         * annotate.el
 
         - each annotation (the overlay, actually) now has a property 'position
@@ -67,3 +67,12 @@
 
           Please note that this changes impacted more or less the whole
           package's code.
+
+2020-03-16 Bastian Bechtold, cage
+        * annotate.el (annotate-annotate)
+
+	- fixed annotation picking in 'annotate-annotate'
+          at  the  beginning  of  the  function we  was  picking  the  first
+	  available  overlay.   So  the annotated  text  contained  multiple
+	  overlays and an  annotation was not the first we  missed the last,
+	  This means, for example, that the annotation was not modifiable.

--- a/NEWS.org
+++ b/NEWS.org
@@ -101,5 +101,8 @@
     file, if exists, to reflect the changes;
   - fixed flowings of annotatinons when window's width is changed.
 
-- 2020-04-06 V0.6.0 Bastian Bechtold, cage ::
+- 2020-03-06 V0.6.0 Bastian Bechtold, cage ::
   Fixed bugs of multiline annotations, diff exports and integration.
+
+- 2020-03-16 V0.6.1 Bastian Bechtold, cage ::
+  Fixed annotation picking in 'annotate-annotate'.

--- a/README.org
+++ b/README.org
@@ -132,7 +132,7 @@ as comments into the current buffer, like this:
   is shown below:
 
 #+BEGIN_SRC text
- [file-mask] [(and | or) [not] regex-note (and | or) [not] regexp-note ...]
+ [file-mask] [(and | or) [not] regex-note [(and | or) [not] regexp-note ...]]
 #+END_SRC
 
 where

--- a/annotate.el
+++ b/annotate.el
@@ -385,7 +385,7 @@ modified (for example a newline is inserted)."
                    (annotate-bounds)
                  (let ((annotation-text (read-from-minibuffer annotate-annotation-prompt)))
                    (annotate-create-annotation start end annotation-text nil)))))
-    (let ((overlay (car (overlays-at (point)))))
+    (let ((annotation (annotate-annotation-at (point))))
       (cond
        ((use-region-p)
         (let ((annotations (cl-remove-if-not #'annotationp
@@ -394,7 +394,7 @@ modified (for example a newline is inserted)."
           (if annotations
               (message "Error: the region overlaps with at least an already existings annotation")
             (create-new-annotation))))
-       ((annotationp overlay)
+       (annotation
         (annotate-change-annotation (point))
         (font-lock-fontify-buffer nil))
        (t

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 0.6.0
+;; Version: 0.6.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -55,7 +55,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "0.6.0"
+  :version "0.6.1"
   :group 'text)
 
 ;;;###autoload
@@ -2417,7 +2417,7 @@ Note: this function return the annotation part of the record, see
 
 The argument `query' is a string that respect a simple syntax:
 
-- [file-mask] [(and | or) [not] regex-note (and | or) [not] regexp-note ...]
+- [file-mask] [(and | or) [not] regex-note [(and | or) [not] regexp-note ...]]
 
 where
 


### PR DESCRIPTION
Hello Bastian!
The fix proposed is simple fix but the bug was bad! ;)

Bye!
C. 

-----
At the beginning of the function  mentioned above we was picking the
first available  overlay.  But if the annotated  text contained multiple
overlays (at least one more of the annotation) and the annotation was  not the first we missed the overlay we was looking for (i.e. the annotation).

This means, for example, that the annotation was not modifiable.

edit: rephrased the fix description.