### PR TITLE
Ensure `face-attribute` is invoke on faces only

### DIFF
--- a/annotate.el
+++ b/annotate.el
@@ -1539,7 +1539,7 @@ The searched interval can be customized setting the variable:
                        (setf all-faces-height
                              (mapcar (lambda (face)
                                        (face-attribute face :height nil 'default))
-                                     (cl-remove-if #'null all-faces)))
+                                     (cl-remove-if-not #'facep all-faces)))
                        (setf force-newline-p
                              (cl-find-if (lambda (a) (/= a default-face-height))
                                          all-faces-height))


### PR DESCRIPTION
somehow `all-faces` may contain inline face attributes or lists, and
`face-attribute` will error out on non face objects