### PR TITLE
- fixed managing return value of "(get-text-property changed-face-pos 'face)"

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -76,3 +76,17 @@
 	  available  overlay.   So  the annotated  text  contained  multiple
 	  overlays and an  annotation was not the first we  missed the last,
 	  This means, for example, that the annotation was not modifiable.
+2020-03-16 Bastian Bechtold, cage
+        * annotate.el (annotate-create-annotation)
+
+	- fixed managing return value of
+	"(get-text-property changed-face-pos 'face)"
+
+	When finding  the face of a portion  of buffer, to try to  get the right
+	positioning   of   the    annotation,   using:
+
+	"(get-text-property changed-face-pos 'face)"
+
+	the code  assumed this function returned  a symbol (the face  of the
+	text) or nil: this is  incorrect according to the documentation; the
+	code above can returns a symbol, a plist or even list of symbols.

--- a/NEWS.org
+++ b/NEWS.org
@@ -109,3 +109,5 @@
 
 - 2020-03-25 V0.6.2 Bastian Bechtold, cage ::
   Fixed bug that prevent annotation of text with complex faces definition.
+  Thanks to the person who filed the issue
+  (see: https://github.com/bastibe/annotate.el/pull/63)

--- a/NEWS.org
+++ b/NEWS.org
@@ -106,3 +106,6 @@
 
 - 2020-03-16 V0.6.1 Bastian Bechtold, cage ::
   Fixed annotation picking in 'annotate-annotate'.
+
+- 2020-03-25 V0.6.2 Bastian Bechtold, cage ::
+  Fixed bug that prevent annotation of text with complex faces definition.

--- a/annotate.el
+++ b/annotate.el
@@ -1538,7 +1538,17 @@ The searched interval can be customized setting the variable:
                                all-faces))
                        (setf all-faces-height
                              (mapcar (lambda (face)
-                                       (face-attribute face :height nil 'default))
+                                       (cond
+                                        ((facep face)
+                                         (face-attribute face :height nil 'default))
+                                        ((and (consp face)
+                                              (keywordp (cl-first face))) ; a plist
+                                         (cl-getf face :height
+                                                  (face-attribute 'default :height)))
+                                        ((consp face) ; a list of named face, first wins
+                                         (face-attribute (cl-first face) :height nil 'default))
+                                        (t
+                                         (face-attribute 'default :height))))
                                      (cl-remove-if #'null all-faces)))
                        (setf force-newline-p
                              (cl-find-if (lambda (a) (/= a default-face-height))

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 0.6.1
+;; Version: 0.6.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -55,7 +55,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "0.6.1"
+  :version "0.6.2"
   :group 'text)
 
 ;;;###autoload


### PR DESCRIPTION
Hello!

When finding  the face of a portion  of buffer, to try to  get the right
positioning   of   the    annotation,   using:

`(get-text-property changed-face-pos 'face)`

the code  assumed this function returned  a symbol (the face  of the
text) or nil: this is  incorrect according to the documentation; the
code above can returns a symbol, a plist or even list of symbols!

This patch try  to deal with the different types  of object the above
code can returns.

see: #63 

Bye!
C.