### PR TITLE
- added a couple of functions to allow an user to change annotation database

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,10 +1,15 @@
+2020-06-09 Bastian Bechtold, cage
+	* annotate.el (annotate-buffers-annotate-mode, annotate-switch-db)
+	- added functions to switch the database of annotations used for the emacs session;
+	- increased version to 0.7.1
+
 2020-05-18 Bastian Bechtold, cage
 	* annotate.el
 	- Increased version to 0.7.0 for stable release
 
 2020-01-25 Bastian Bechtold, cage
 
-        * annotate.el (defun annotate-annotation-force-newline-policy,
+        * annotate.el (annotate-annotation-force-newline-policy,
                        annotate-annotation-newline-policy-forced-p,
                        annotate-create-annotation,
                        annotate-lineate,

--- a/Changelog
+++ b/Changelog
@@ -1,7 +1,7 @@
 2020-06-09 Bastian Bechtold, cage
 	* annotate.el (annotate-buffers-annotate-mode, annotate-switch-db)
 	- added functions to switch the database of annotations used for the emacs session;
-	- increased version to 0.7.1
+	- increased version to 0.8.0
 
 2020-05-18 Bastian Bechtold, cage
 	* annotate.el

--- a/NEWS.org
+++ b/NEWS.org
@@ -114,3 +114,6 @@
 
 - 2020-05-18 V0.7.0 Bastian Bechtold, cage ::
   Increased version to 0.7.0 for stable release
+
+- 2020-06-09 V0.7.1 Bastian Bechtold, cage ::
+  The database of annotation can be changed using the command ~annotate-switch-db~.

--- a/NEWS.org
+++ b/NEWS.org
@@ -115,5 +115,5 @@
 - 2020-05-18 V0.7.0 Bastian Bechtold, cage ::
   Increased version to 0.7.0 for stable release
 
-- 2020-06-09 V0.7.1 Bastian Bechtold, cage ::
+- 2020-06-09 V0.8.0 Bastian Bechtold, cage ::
   The database of annotation can be changed using the command ~annotate-switch-db~.

--- a/README.org
+++ b/README.org
@@ -30,8 +30,16 @@ previous annotation.
 
 ** Metadata
 
-All  annotations are  saved  in  ~annotate-file~ (=~/.annotations=  by
-default).
+The  current  database  for  annotations  is  contained  in  the  file
+indicated by the variable ~annotate-file~ (=~/.emacs.d/annotations= by
+default) but  each user can change  this value in a  dynamic way using
+the  command ~annotate-switch-db~.   This  command will  take care  to
+refresh/redraw   all   annotations   in    the   buffers   that   uses
+~annotate-mode~.
+
+Please note that switching database,  in this context, means rebinding
+the  aforementioned variable  (~annotate-file~).  This  means than  no
+more than a single database can be active for each Emacs session.
 
 Users of
 [[https://github.com/emacscollective/no-littering][no-littering]]

--- a/annotate.el
+++ b/annotate.el
@@ -2489,5 +2489,51 @@ annotation, like this:
 
 ;;;; end of filtering: parser, lexer, etc.
 
+;;;; switching database
+
+(defun annotate-buffers-annotate-mode ()
+ "Returns a list of all the buffers that have
+annotate minor mode active"
+  (let ((all-buffers (buffer-list)))
+    (cl-labels ((annotate-mode-p (buffer)
+                  (with-current-buffer buffer
+                    (and (boundp 'annotate-mode)
+                         annotate-mode))))
+      (cl-remove-if-not #'annotate-mode-p all-buffers))))
+
+(cl-defun annotate-switch-db (&optional (force-load nil))
+ "Ask the user for a new annotation database files, load it and
+refresh all the annotations contained in each buffer where
+annotate minor mode is active.
+
+If `force-load' is non nil no prompt asking user for confirmation
+about loading the new file is shown.
+
+Note: this function will attempt to load (compile and
+eval/execute) the content of the file as it was elisp source
+code, always use load files from trusted sources!"
+  (interactive)
+  (let ((new-db (read-file-name "Database file location: ")))
+    (when (not (annotate-string-empty-p new-db))
+      (if (file-exists-p new-db)
+          (let* ((confirm-message "Loading elisp file from untrusted source may results in severe security problems. Load %S? [y/N]")
+                 (load-file-confirmed (if force-load
+                                          t
+                                        (string= (read-from-minibuffer (format confirm-message
+                                                                               new-db))
+                                                 "y"))))
+            (if load-file-confirmed
+                (progn
+                  (setf annotate-file new-db)
+                  (cl-loop for annotated-buffer in (annotate-buffers-annotate-mode) do
+                           (with-current-buffer annotated-buffer
+                             (annotate-with-inhibit-modification-hooks
+                              (annotate-mode -1)
+                              (annotate-mode  1)))))
+              (message "Load aborted by the user")))
+        (user-error (format "The file %S does not exists." new-db))))))
+
+;; end of switching database
+
 (provide 'annotate)
 ;;; annotate.el ends here

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 0.7.1
+;; Version: 0.8.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -55,7 +55,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "0.7.1"
+  :version "0.8.0"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 0.7.0
+;; Version: 0.7.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -55,7 +55,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "0.7.0"
+  :version "0.7.1"
   :group 'text)
 
 ;;;###autoload
@@ -2516,7 +2516,7 @@ code, always use load files from trusted sources!"
   (let ((new-db (read-file-name "Database file location: ")))
     (when (not (annotate-string-empty-p new-db))
       (if (file-exists-p new-db)
-          (let* ((confirm-message "Loading elisp file from untrusted source may results in severe security problems. Load %S? [y/N]")
+          (let* ((confirm-message "Loading elisp file from untrusted source may results in severe security problems. Load %S? [y/N] ")
                  (load-file-confirmed (if force-load
                                           t
                                         (string= (read-from-minibuffer (format confirm-message
@@ -2527,9 +2527,12 @@ code, always use load files from trusted sources!"
                   (setf annotate-file new-db)
                   (cl-loop for annotated-buffer in (annotate-buffers-annotate-mode) do
                            (with-current-buffer annotated-buffer
-                             (annotate-with-inhibit-modification-hooks
-                              (annotate-mode -1)
-                              (annotate-mode  1)))))
+                             (let ((buffer-was-modified-p (buffer-modified-p annotated-buffer)))
+                               (annotate-with-inhibit-modification-hooks
+                                (annotate-mode -1)
+                                (annotate-mode  1)
+                                (when (not buffer-was-modified-p)
+                                  (set-buffer-modified-p nil)))))))
               (message "Load aborted by the user")))
         (user-error (format "The file %S does not exists." new-db))))))
 


### PR DESCRIPTION
Hi Bastian!

With this PR i tried to address (tangentially, to be honest) the problem exposed in #68.

The proposed modifications supposed to reload the database that contains the annotations and then iterate on all the  buffers that uses `annotate-mode` refreshing the annotation in each buffer.

It is a bit crude but my impression is that works.

Honestly i do not think this package should deal with control version system, like asked in #68, l but  i also think that using this function @gopar or other users could be able write some code to get a different annotation file per git branch.

Bye!
C.
