### PR TITLE
Fixed a regression  and some bugs related to  incorrect calculation of multiline annotations.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+2020-11-22  cage
+
+        * annotate.el:
+
+	- added more docstrings.
+
 2020-11-12  cage
 
         * annotate.el:

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,117 @@
+2020-11-12  cage
+
+        * annotate.el:
+
+	- prevented getting shared value for 'annotate-file' in
+        '%load-annotation-data'.
+
+	This  way  we can  ensure  that  'annotate-file' can  be  declared
+	buffer-local and  different annotation  databases can be  used from
+	different buffers.
+
+2020-11-11  cage
+
+        * annotate.el:
+	- fitted 'annotate-position-inside-chain-p' into   'annotate--position-inside-annotated-text-p';
+	- fixed some typos.
+
+2020-11-06  cage
+
+        * annotate.el:
+
+	- Fixed a regression  and some bugs related to
+        incorrect calculation of of multiline annotations.
+
+	To reproduce the bugs:
+
+	legend:
+
+	a = annotated text
+	* = non annotated text
+
+	- First bug
+
+	Create a multiline annotation using region.
+
+	aaaa
+	aaaa
+	aaaa    ####
+
+	Place the cursor as below.
+
+	aaaa
+	^ cursor
+	aaaa
+	aaaa    ####
+
+	type a character
+
+	a****
+	aaaa
+	aaaa    ####
+
+	The annotated text has a "gap"
+
+	Fix proposed: revert to the old (correct behaviour)
+
+	Second bug
+
+	aaaa
+	aaaa
+	aaaa    ####
+
+	Place the cursor as below.
+
+	aaaa
+	^ cursor on the first column
+	aaaa
+	aaaa    ####
+
+	type some text
+
+	***
+	aaa
+	aaa    ####
+
+	Save (C-x C-s)
+
+	you  get an  error  on  the echo  area:  "let*:  Wrong type  argument:
+	overlayp, nil" and the annotations are not correctly saved.
+
+	Fix proposed: remove the offending code.
+
+	Third bug
+
+	a multiline bug as before
+
+	aaaa
+	aaaa
+	aaaa    ####
+
+	place the cursor here:
+
+	aaaa
+	aaaa
+	^ cursor
+	aaaa    ####
+
+	type some text
+
+	aaaa
+	*****
+	aaaa    ####
+
+	Then annotate the same line (C-c C-a):
+
+	aaaa
+	aaaa    ####
+	aaaa    ####
+
+	we  introduced  a  annotation  in  the gap  of  the  already  existing
+	multiline annotation.
+
+	Fix proposed: prevents annotating text inside an annotation.
+
 2020-09-29
         * README.org, annotate.el
 	- updated README;

--- a/NEWS.org
+++ b/NEWS.org
@@ -130,3 +130,20 @@
 - 2020-09-29 V0.9.0 Bastian Bechtold, cage ::
   Added two new styles to render the annotation: using "pop-up" style
   or via a specializated summary window.
+
+- 2020-11-20 V0.9.2 Bastian Bechtold, cage ::
+
+  This version fix a regression and  some more bug that could breaks a
+  multiline  annotation  in  ways  that makes  the  annotation  system
+  inconsistent  and  renders the  annotated  text  in wrong  way  (for
+  details see the Changelog).
+
+  The 'annotate-file' can be now  safely declared buffer-local so that
+  multiple databases of annotations can be used on a per-buffer basis.
+
+  For pratical applications see:
+
+  https://github.com/bastibe/annotate.el/issues/68
+
+  Many thanks to gopar for spotting  this elusive bug and help testing
+  the patch! :)

--- a/annotate.el
+++ b/annotate.el
@@ -1340,16 +1340,19 @@ annotation."
 (defun annotate-load-annotation-data (&optional ignore-errors)
   "Read and return saved annotations."
   (cl-flet ((%load-annotation-data ()
-              (with-temp-buffer
-                (if (file-exists-p annotate-file)
-                    (insert-file-contents annotate-file)
-                  (signal 'annotate-db-file-not-found (list annotate-file)))
-                (goto-char (point-max))
-                (cond ((= (point) 1)
-                       nil)
-                      (t
-                       (goto-char (point-min))
-                       (read (current-buffer)))))))
+              (let ((annotations-file annotate-file))
+                (with-temp-buffer
+                  (let* ((annotate-file annotations-file)
+                         (attributes    (file-attributes annotate-file)))
+                    (cond
+                     ((not (file-exists-p annotate-file))
+                      (signal 'annotate-db-file-not-found (list annotate-file)))
+                     ((= (file-attribute-size attributes)
+                         0)
+                      nil)
+                     (t
+                      (insert-file-contents annotate-file)
+                      (read (current-buffer)))))))))
     (if ignore-errors
         (ignore-errors (%load-annotation-data))
       (%load-annotation-data))))

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 0.9.0
+;; Version: 0.9.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "0.9.0"
+  :version "0.9.2"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -344,7 +344,7 @@ See: `annotate-annotation-position-policy'
 
 (defun annotate-annotation-newline-policy-forced-p (annotation)
   "Is `annotation' forced  to place annotation on the  line after the
-annoateted text?
+annotated text?
 
 See: `annotate-annotation-position-policy'"
   (overlay-get annotation 'force-newline-policy))

--- a/annotate.el
+++ b/annotate.el
@@ -336,12 +336,38 @@ position (so that it is unchanged after this function is called)."
      (overlay-end   annotation)))
 
 (defun annotate-annotation-force-newline-policy (annotation)
+  "Force annotate to place `annotation' on the line after the annotated text.
+
+See: `annotate-annotation-position-policy'
+"
   (overlay-put annotation 'force-newline-policy t))
 
 (defun annotate-annotation-newline-policy-forced-p (annotation)
+  "Is `annotation' forced  to place annotation on the  line after the
+annoateted text?
+
+See: `annotate-annotation-position-policy'"
   (overlay-get annotation 'force-newline-policy))
 
 (defun annotate--remap-chain-pos (annotations)
+  "Remap an annotation 'chain'
+
+An annotation is a collection of one or more overlays that
+contains the property `annotate-prop-chain-position'.
+
+The value of `annotate-prop-chain-position' in each chain is an
+integer starting from:
+
+`annotate-prop-chain-pos-marker-first' and *always* ending with
+
+`annotate-prop-chain-pos-marker-last'
+
+This means that a value of said property for a chain that
+contains only an element is equal to
+`annotate-prop-chain-pos-marker-last'.
+
+This function ensure this constrains for the chain `annotation'
+belong."
   (cond
    ((< (length annotations)
        1)
@@ -1894,6 +1920,9 @@ NOTE this assumes that annotations never overlaps"
           (right-ends))))
 
 (defun annotate-make-annotation (beginning ending annotation annotated-text)
+ "Make an annotation record that represent an annotation
+starting at `beginning', terminate at `ending' with annotation
+content `annotation' and annotated text `annotated-text'."
   (list beginning ending annotation annotated-text))
 
 (defun annotate-all-annotations ()
@@ -1986,6 +2015,8 @@ sophisticated way than plain text"
           (goto-char (button-get button 'go-to))))))))
 
 (defun annotate-summary-delete-annotation-button-pressed (button)
+ "Callback for summary window fired when a 'delete' button is
+pressed."
   (let* ((filename        (button-get button 'file))
          (beginning       (button-get button 'beginning))
          (ending          (button-get button 'ending))
@@ -2016,6 +2047,8 @@ sophisticated way than plain text"
       (update-visited-buffer-maybe))))
 
 (defun annotate-summary-replace-annotation-button-pressed (button)
+   "Callback for summary window fired when a 'replace' button is
+pressed."
   (let* ((filename             (button-get button 'file))
          (annotation-beginning (button-get button 'beginning))
          (annotation-ending    (button-get button 'ending))


### PR DESCRIPTION
Hi @bastibe !

I introduced some regression and i failed to manage correctly the multi line annotations. :(
The bugs are too difficult for me to explain so i preferred to add use cases to reproduce the issues and proposed fix. Hope this is OK.

There are some thing still missing in this PR (probably just a couple of docstrings) but the bulk of the fix is here, i submitted this PR now so that maybe some user can test this branch and help with testing and i am going to check later what is missing.

Fortunately seems to me that some of the code here should be useful for #83!

Bye!!
C.

``` text
To reproduce the bugs:

legend:

a = annotated text
* = non annotated text

- First bug

Create a multiline annotation using region.

aaaa
aaaa
aaaa    ####

Place the cursor as below.

aaaa
 ^ cursor
aaaa
aaaa    ####

type a character

a****
aaaa
aaaa    ####

The annotated text has a "gap"

Fix proposed: revert to the old (correct behaviour)

Second bug

aaaa
aaaa
aaaa    ####

Place the cursor as below.

aaaa
^ cursor on the first column
aaaa
aaaa    ####

type some text

***
aaa
aaa    ####

Save (C-x C-s)

you  get an  error  on  the echo  area:  "let*:  Wrong type  argument:
overlayp, nil" and the annotations are not correctly saved.

Fix proposed: remove the offending code.

Third bug

a multiline bug as before

aaaa
aaaa
aaaa    ####

place the cursor here:

aaaa
aaaa
^ cursor
aaaa    ####

type some text

aaaa
*****
aaaa    ####

Then annotate the same line (C-c C-a):

aaaa
aaaa    ####
aaaa    ####

we  introduced  a  annotation  in  the gap  of  the  already  existing
multiline annotation.

Fix proposed: prevents annotating text inside an annotation.

```