### PR TITLE
Expand db path and improving visuals of multiline annotation text

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,43 @@
+2020-12-19  cage
+
+        * annotate.el:
+
+	-   moved  'save-match-data'   from   the   function  that   calls
+	'annotate--split-lines' inside  the body of the  latter; to remove
+	any side-effect.
+
+2020-12-19  cage
+
+        * annotate.el:
+
+	- fixed the width of the last row of the box
+
+2020-12-19  cage
+
+        * annotate.el:
+
+	- wrapped 'annotate-wrap-annotation-in-box' with 'save-match-data.
+
+2020-12-19  cage
+
+        * annotate.el:
+
+	- added procedures to pad multiline annotation text.
+
+2020-12-18  cage
+
+        * annotate.el:
+
+	- extracted  local function  and taken  into account  info node
+        names (that should not be expanded).
+
+2020-12-18  cage
+
+        * annotate.el:
+
+	-  stored abbreviated  filenames for  the path  component of  each
+	record of the annotations database; - improved a docstring.
+
 2020-12-16 cage
 
 	* Changelog, NEWS.org, annotate.el:

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,43 @@
+2020-12-23  cage
+
+        * annotate.el:
+
+	- changed customizable  variable related to exporting.   As we are
+	using  diff-mode   could  instruct   the  executable   to  operate
+	accordingly to a command line.
+
+2020-12-23  cage
+
+        * annotate.el:
+
+	- rewritten export and integrate of annotations export use now the
+	Emacs diff functions to generate a buffer containing the patch.
+
+2020-12-23  cage
+
+        * annotate.el:
+
+	- fixed export for annotated text made from a single line.
+
+2020-12-22  cage
+
+        * annotate.el:
+
+	- removed code, in integration procedures, that should never runs.
+
+2020-12-22  cage
+
+        * annotate.el:
+
+	- fixed integration of multiline annotated text.
+
+2020-12-20  cage
+
+        * Changelog, NEWS.org, annotate.el:
+
+	- updated version;
+	- updated NEWS and Changelog (also fixed grammar for the former).
+
 2020-12-19  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -160,7 +160,7 @@
 
   Also a problem with adjacent annotation's coloring has been fixed.
 
-- 2020-12-20 V1.1.0 Bastian Bechtold, cage ::
+- 2020-12-24 V1.1.0 Bastian Bechtold, cage ::
 
   This version  improves the  visual style of  annotated text  that if
   formed by more than one line.
@@ -172,3 +172,8 @@
 
   This  improvements has  been suggested  by  the user  Ran that  also
   helped testing this new version of the package. Thank you!
+
+  Finally import and export of annotation has been fixed.
+
+  Related to the last  fix the variable ~annotate-diff-export-context~
+  has been removed.

--- a/NEWS.org
+++ b/NEWS.org
@@ -99,7 +99,7 @@
   - when an user delete an annotation for a file using a button from
     summary window force refresh of a buffer that is visiting said
     file, if exists, to reflect the changes;
-  - fixed flowings of annotatinons when window's width is changed.
+  - fixed flowings of annotations when window's width is changed.
 
 - 2020-03-06 V0.6.0 Bastian Bechtold, cage ::
   Fixed bugs of multiline annotations, diff exports and integration.
@@ -129,7 +129,7 @@
 
 - 2020-09-29 V0.9.0 Bastian Bechtold, cage ::
   Added two new styles to render the annotation: using "pop-up" style
-  or via a specializated summary window.
+  or via a specialized summary window.
 
 - 2020-11-20 V0.9.2 Bastian Bechtold, cage ::
 
@@ -159,3 +159,16 @@
   annotation database's' hash and file has do not match;
 
   Also a problem with adjacent annotation's coloring has been fixed.
+
+- 2020-12-20 V1.1.0 Bastian Bechtold, cage ::
+
+  This version  improves the  visual style of  annotated text  that if
+  formed by more than one line.
+
+  Also  the file  path  of each  annotated file  (in  the database  of
+  annotation)     is    saved     so    called     abbreviated    form
+  (e.g. '/home/user/foo' is saved as  '~/foo', this could be useful if
+  the database is migrated from one machine to another.
+
+  This  improvements has  been suggested  by  the user  Ran that  also
+  helped testing this new version of the package. Thank you!

--- a/README.org
+++ b/README.org
@@ -120,7 +120,7 @@ as comments into the current buffer, like this:
 
 **** related customizable variable
      - ~annotate-integrate-marker~
-     - ~annotate-diff-export-context~
+     - ~annotate-diff-export-options~
      - ~annotate-integrate-highlight~
      - ~annotate-fallback-comment~
 

--- a/annotate.el
+++ b/annotate.el
@@ -115,9 +115,11 @@ text lines and annotation text)."
   :type 'number
   :group 'annotate)
 
-(defcustom annotate-diff-export-context 8
-  "How many lines of context to include in diff export."
-  :type 'number
+(defcustom annotate-diff-export-options ""
+ "Other options for diffing between a buffer with and without integrated annotations.
+Note that thre is an oimplicit -u at the end of default options
+that Emacs passes to the diff program"
+  :type 'string
   :group 'annotate)
 
 (defcustom annotate-use-messages t
@@ -814,7 +816,7 @@ This diff does not contain any changes, but highlights the
 annotation, and can be conveniently viewed in diff-mode."
   (interactive)
   (let ((buffer (annotate--integrate-annotations :switch-to-new-buffer nil)))
-    (diff-buffers (current-buffer) buffer "-u")))
+    (diff-buffers (current-buffer) buffer annotate-diff-export-options)))
 
 (defun annotate--font-lock-matcher (limit)
   "Finds the next annotation. Matches two areas:

--- a/annotate.el
+++ b/annotate.el
@@ -117,7 +117,7 @@ text lines and annotation text)."
 
 (defcustom annotate-diff-export-options ""
  "Other options for diffing between a buffer with and without integrated annotations.
-Note that thre is an oimplicit -u at the end of default options
+Note that there is an implicit -u at the end of default options
 that Emacs passes to the diff program"
   :type 'string
   :group 'annotate)

--- a/annotate.el
+++ b/annotate.el
@@ -1031,7 +1031,8 @@ to 'maximum-width'."
 
 (cl-defun annotate--split-lines (text &optional (separator "\n"))
   "Returns text splitted by `separator' (default: \"\n\")"
-  (split-string text "\n"))
+  (save-match-data
+    (split-string text "\n")))
 
 (defun annotate-wrap-annotation-in-box (annotation-overlay
                                         begin-of-line
@@ -1051,30 +1052,29 @@ aaa      aaa
 aa   ->  aa*
 a        a**
 "
-  (save-match-data
-    (let ((annotation-text (overlay-get annotation-overlay 'annotation)))
-      (cl-labels ((boxify-multiline ()
-                    (let* ((lines         (annotate--split-lines annotation-text))
-                           (lines-widths  (mapcar 'string-width lines))
-                           (max-width     (cl-reduce (lambda (a b) (if (> a b)
-                                                                       a
-                                                                     b))
-                                                     lines-widths
-                                                     :initial-value -1))
-                           (padding-sizes (mapcar (lambda (a) (- max-width
-                                                                 (string-width a)))
-                                                  lines))
-                           (paddings      (mapcar (lambda (a) (make-string a ? ))
-                                                  padding-sizes))
-                           (box-lines     (cl-mapcar (lambda (a b) (concat a b))
-                                                     lines paddings))
-                           (almost-boxed  (cl-reduce (lambda (a b) (concat a "\n" b))
-                                                     box-lines)))
-                      (concat almost-boxed " "))))
-        (if annotation-on-is-own-line-p
-            (list (boxify-multiline))
-          (annotate--split-lines (annotate-lineate annotation-text
-                                                   (- end-of-line begin-of-line))))))))
+  (let ((annotation-text (overlay-get annotation-overlay 'annotation)))
+    (cl-labels ((boxify-multiline ()
+                  (let* ((lines         (annotate--split-lines annotation-text))
+                         (lines-widths  (mapcar 'string-width lines))
+                         (max-width     (cl-reduce (lambda (a b) (if (> a b)
+                                                                     a
+                                                                   b))
+                                                   lines-widths
+                                                   :initial-value -1))
+                         (padding-sizes (mapcar (lambda (a) (- max-width
+                                                               (string-width a)))
+                                                lines))
+                         (paddings      (mapcar (lambda (a) (make-string a ? ))
+                                                padding-sizes))
+                         (box-lines     (cl-mapcar (lambda (a b) (concat a b))
+                                                   lines paddings))
+                         (almost-boxed  (cl-reduce (lambda (a b) (concat a "\n" b))
+                                                   box-lines)))
+                    (concat almost-boxed " "))))
+      (if annotation-on-is-own-line-p
+          (list (boxify-multiline))
+        (annotate--split-lines (annotate-lineate annotation-text
+                                                 (- end-of-line begin-of-line)))))))
 
 (defun annotate--annotation-builder ()
   "Searches the line before point for annotations, and returns a

--- a/annotate.el
+++ b/annotate.el
@@ -711,62 +711,7 @@ An example might look like this:"
                           (< (overlay-start o1)
                              (overlay-start o2)))))
         (goto-char (overlay-start ov))
-        (cond
-         ;; overlay spans more than one line
-         ;; IMPORTANT NOTE:
-         ;; this branch is vestigial: a single annotation
-         ;; overlay can *not* spans for more that one line after
-         ;; chains has been introduced, therefore this code branch
-         ;; never runs and should be removed
-         ((string-match "\n" (buffer-substring (overlay-start ov)
-                                               (overlay-end ov)))
-          ;; partially underline first line
-          (let ((ov-start (point))
-                (bol (progn (beginning-of-line)
-                            (point)))
-                (eol (progn (end-of-line)
-                            (point))))
-            (end-of-line)
-            (insert "\n"
-                    (annotate-wrap-in-comment (make-string (max 0
-                                                                (- ov-start
-                                                                   bol
-                                                                   (annotate-comments-length)))
-                                                           ? )
-                                              (make-string (max 0 (- eol ov-start))
-                                                           annotate-integrate-higlight))))
-          ;; fully underline second to second-to-last line
-          (while (< (progn (forward-line)
-                           (end-of-line)
-                           (point))
-                    (overlay-end ov))
-            (let ((bol (progn (beginning-of-line)
-                              (point)))
-                  (eol (progn (end-of-line)
-                              (point))))
-              (end-of-line)
-              (insert "\n"
-                      (annotate-wrap-in-comment (make-string (max 0
-                                                                  (- eol
-                                                                     bol
-                                                                     (annotate-comments-length)))
-                                                             annotate-integrate-higlight)))))
-          ;; partially underline last line
-          (let ((bol (progn (beginning-of-line)
-                            (point)))
-                (ov-end (overlay-end ov)))
-            (end-of-line)
-            (insert "\n"
-                    (annotate-wrap-in-comment (make-string (max 0
-                                                                (- ov-end
-                                                                   bol
-                                                                   (annotate-comments-length)))
-                                                           annotate-integrate-higlight))))
-          ;; insert actual annotation text
-          (insert (wrap-annotation-text (overlay-get ov 'annotation))))
-         ;; overlay is within one line
-         (t
-          (let* ((ov-start         (overlay-start ov))
+        (let* ((ov-start         (overlay-start ov))
                  (ov-end           (overlay-end ov))
                  (bol              (progn (beginning-of-line)
                                           (point)))
@@ -786,8 +731,8 @@ An example might look like this:"
             (when (annotate-chain-last-p ov)
               (let ((annotation-integrated-text (wrap-annotation-text (overlay-get ov
                                                                                    'annotation))))
-                (insert "\n" annotation-integrated-text)))))))
-      (annotate-clear-annotations))))
+                (insert "\n" annotation-integrated-text))))))
+    (annotate-clear-annotations)))
 
 (defun annotate-export-annotations ()
   "Export all annotations as a unified diff file.

--- a/annotate.el
+++ b/annotate.el
@@ -1051,30 +1051,31 @@ aaa      aaa
 aa   ->  aa*
 a        a**
 "
-  (let ((annotation-text (overlay-get annotation-overlay 'annotation)))
-    (cl-labels ((boxify-multiline ()
-                  (let* ((lines         (annotate--split-lines annotation-text))
-                         (lines-widths  (mapcar 'string-width lines))
-                         (max-width     (cl-reduce (lambda (a b) (if (> a b)
-                                                                     a
-                                                                   b))
-                                                   lines-widths
-                                                   :initial-value -1))
-                         (padding-sizes (mapcar (lambda (a) (max (- max-width
-                                                                    (string-width a)
-                                                                    1)
-                                                                 0))
-                                                lines))
-                         (paddings      (mapcar (lambda (a) (make-string a ? ))
-                                                padding-sizes))
-                         (box-lines     (cl-mapcar (lambda (a b) (concat a b))
-                                                   lines paddings)))
-                    (cl-reduce (lambda (a b) (concat a "\n" b))
-                               box-lines))))
+  (save-match-data
+    (let ((annotation-text (overlay-get annotation-overlay 'annotation)))
+      (cl-labels ((boxify-multiline ()
+                    (let* ((lines         (annotate--split-lines annotation-text))
+                           (lines-widths  (mapcar 'string-width lines))
+                           (max-width     (cl-reduce (lambda (a b) (if (> a b)
+                                                                       a
+                                                                     b))
+                                                     lines-widths
+                                                     :initial-value -1))
+                           (padding-sizes (mapcar (lambda (a) (max (- max-width
+                                                                      (string-width a)
+                                                                      1)
+                                                                   0))
+                                                  lines))
+                           (paddings      (mapcar (lambda (a) (make-string a ? ))
+                                                  padding-sizes))
+                           (box-lines     (cl-mapcar (lambda (a b) (concat a b))
+                                                     lines paddings)))
+                      (cl-reduce (lambda (a b) (concat a "\n" b))
+                                 box-lines))))
 
-      (if annotation-on-is-own-line-p
-          (list (boxify-multiline))
-        (save-match-data
+        (if annotation-on-is-own-line-p
+            (list (boxify-multiline))
+
           (annotate--split-lines (annotate-lineate annotation-text
                                                    (- end-of-line begin-of-line))))))))
 

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.0.0
+;; Version: 1.1.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.0.0"
+  :version "1.1.0"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -1061,21 +1061,18 @@ a        a**
                                                                      b))
                                                      lines-widths
                                                      :initial-value -1))
-                           (padding-sizes (mapcar (lambda (a) (max (- max-width
-                                                                      (string-width a)
-                                                                      1)
-                                                                   0))
+                           (padding-sizes (mapcar (lambda (a) (- max-width
+                                                                 (string-width a)))
                                                   lines))
                            (paddings      (mapcar (lambda (a) (make-string a ? ))
                                                   padding-sizes))
                            (box-lines     (cl-mapcar (lambda (a b) (concat a b))
-                                                     lines paddings)))
-                      (cl-reduce (lambda (a b) (concat a "\n" b))
-                                 box-lines))))
-
+                                                     lines paddings))
+                           (almost-boxed  (cl-reduce (lambda (a b) (concat a "\n" b))
+                                                     box-lines)))
+                      (concat almost-boxed " "))))
         (if annotation-on-is-own-line-p
             (list (boxify-multiline))
-
           (annotate--split-lines (annotate-lineate annotation-text
                                                    (- end-of-line begin-of-line))))))))
 


### PR DESCRIPTION
Hi!

I have changed the loading and saving of annotations database to implements #89.

For each record of the database the file component  is abbreviated when saved and expanded (if required, i tried to not expand info nodes) when loaded.

Also implemented #90.  

Bye!
C.