### PR TITLE
prevented side effects of 'split-string'

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,10 @@
+2021-01-06  cage
+
+        * annotate.el:
+
+	- prevented side effects of 'split-string'.
+
+
 2020-12-23  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -177,3 +177,8 @@
 
   Related to the last  fix the variable ~annotate-diff-export-context~
   has been removed.
+
+* 2021-01-06 V1.1.1 Bastian Bechtold, cage ::
+
+  This version  fix an old bug  that causes many types  of issues with
+  rendering of annotations on the margin of the window.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.1.0
+;; Version: 1.1.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.1.0"
+  :version "1.1.1"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -920,10 +920,12 @@ to 'maximum-width'."
                           (%group (append (list suffix)
                                           (cl-rest rest-words))
                                   (append (list prefix)
-                                          so-far)))))))
+                                          so-far))))))
+              (%split-words (text)
+                (save-match-data (split-string text " " t))))
     (if (< maximum-width 1)
         nil
-      (let* ((words   (split-string text " " t))
+      (let* ((words   (%split-words text))
              (grouped (reverse (%group words '()))))
         grouped))))
 


### PR DESCRIPTION
Hi @bastibe ! 

I  think  i  have added  this  bug  many  months  ago and  was  hiding
unnoticed! :) It  was discovered by chance only because  of the latest
code changes related to multi-line annotated text.

Truly i wonder how did the code worked until now! :astonished: 

Bye!
C.