### PR TITLE
Improving visuals of margin notes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,9 @@
+2021-01-14 cage
+
+        * annotate.el:
+
+	- added padding also for notes placed on the margin of the window.
+
 2021-01-06  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -178,7 +178,12 @@
   Related to the last  fix the variable ~annotate-diff-export-context~
   has been removed.
 
-* 2021-01-06 V1.1.1 Bastian Bechtold, cage ::
+- 2021-01-06 V1.1.1 Bastian Bechtold, cage ::
 
   This version  fix an old bug  that causes many types  of issues with
   rendering of annotations on the margin of the window.
+
+- 2021-01-06 V1.1.2 Bastian Bechtold, cage ::
+
+  This  version improves  visual  of multilined  notes  placed on  the
+  window margins.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.1.1
+;; Version: 1.1.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.1.1"
+  :version "1.1.2"
   :group 'text)
 
 ;;;###autoload


### PR DESCRIPTION
Hi @bastibe !

With this patch i tried to improve the  appeareance of the notes placed on the border of the window in the same way @randomwangran suggested for annotation placed on theyr own line (see https://github.com/bastibe/annotate.el/issues/90).

The code was mostly there fortunately! :)

Bye!
C.