### PR TITLE
Added  early checking encrypted (GPG) file format

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,22 @@
+2021-01-15  cage
+
+        * annotate.el:
+
+	- added checking encrypted (GPG) file format.
+
+	In many parts  of the code we  use 'annotate-guess-file-format', a
+	function that  try to guess the  format of the file  that produced
+	the  contents of  a buffer.
+
+	Sometimes (for example  buffers that shows info  nodes) this check
+	is  very   expensive  because   involves  reading   (and  possibly
+	decompress  or even  decrypt) the  file contents  and check  for a
+	regular expression.
+
+	If  we  could know  in  advance  that  the file  is  symmetrically
+	encrypted with GPG we could  skip other, more expensive checks for
+	guessing file format (like info files).
+
 2021-01-14 cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -187,3 +187,8 @@
 
   This  version improves  visual  of multilined  notes  placed on  the
   window margins.
+
+- 2021-01-06 V1.1.3 Bastian Bechtold, cage ::
+
+  Optimized the code to speedup  reading and saving of encrypted (with
+  GPG) annotated files.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.1.2
+;; Version: 1.1.3
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.1.2"
+  :version "1.1.3"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -2212,8 +2212,31 @@ sophisticated way than plain text"
                                          (and has-separator-p
                                               has-info-p))
                                      :info
-                                   nil))))))
-    (info-format-p)))
+                                   nil)))))
+              (gpg-format-p ()
+                            (with-temp-buffer
+                              (let* ((magic-0    #x8c)
+                                     (magic-1    #x0d)
+                                     (magic-4    #x03)
+                                     (magic-5    #x02)
+                                     (attributes (file-attributes filename))
+                                     (file-size  (file-attribute-size attributes)))
+                                (when (> file-size 6)
+                                  (let* ((bytes      (insert-file-contents-literally filename
+                                                                                     nil
+                                                                                     0
+                                                                                     7)))
+                                    (setf bytes
+                                          (cl-loop for i from 1 to 6 collect
+                                                   (elt (buffer-substring-no-properties i (1+ i))
+                                                        0)))
+                                    (when (and (= (logand (elt bytes 0) #x0000ff) magic-0)
+                                               (= (logand (elt bytes 1) #x0000ff) magic-1)
+                                               (= (logand (elt bytes 4) #x0000ff) magic-4)
+                                               (= (logand (elt bytes 5) #x0000ff) magic-5))
+                                      :encrypted-symmetric)))))))
+    (or (gpg-format-p)
+        (info-format-p)))) ;; keep this one for last as it is the slowest
 
 ;;;; summary window procedures
 


### PR DESCRIPTION
Hi @bastibe 

Inspired by the issue reported in  #94 i added the magic number check for GPG encrypted files, from the Changelog:

``` text
    In  many parts  of  the code  we  use 'annotate-guess-file-format',  a
    function that  try to guess the  format of the file  that produced the
    contents of a  buffer. Sometimes (for example buffers  that shows info
    nodes)  this check  is very  expensive because  involves reading  (and
    possibly decompress or even decrypt) the file contents and check for a
    regular expression.
    
    If we could  know in advance that the file  is symmetrically encrypted
    with GPG we could skip other,  more expensive checks for guessing file
    format (like info files).
```
I know that this is probably sort of a corner case (people who annotates encrypted files) but i found no reason to implement it if this can makes life a bit easier for someone :-) (and the code is trivial by the way ;-)).

Bye!
C.

