### PR TITLE
Remove compilation warnings

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,29 @@
+2021-03-14  cage
+
+        * annotate.el:
+
+	- allowed deleting of annotations for info files;
+	- removed useless argument for 'font-lock-flush'.
+
+2021-03-12  cage
+
+        * annotate.el:
+
+	- changed function from 'font-lock-fontify-buffer' to
+	'font-lock-flush';
+	- changed function calls from 'cl' package to the 'cl-lib'
+	equivalents;
+	- added missing argument to 'annotate-create-annotation';
+	- removed unused functions.
+
+2021-03-11  cage
+
+        * annotate.el:
+
+	- removed warning related to misplaced '(interactive)';
+	- removed warning because of expanding a macro that was defined
+	later in the code.
+
 2021-02-05  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -197,3 +197,14 @@
 
   Fixed highlight color  of annotated text that starts  from the first
   character of the buffer's content.
+
+- 2021-02-05 V1.1.5 Bastian Bechtold, cage ::
+
+  Removed compilation  warnings, one of  the problem highlighted  by a
+  warning was actually preventing this package working on Doom Emacs.
+
+  Also a  bug that prevented  annotations placed  on info files  to be
+  deleted has been fixed.
+
+  Many thanks  to many people  that helped discovering  and suggesting
+  fix for these problems!

--- a/annotate.el
+++ b/annotate.el
@@ -430,7 +430,7 @@ modified (for example a newline is inserted)."
   "The function to be called when an info buffer is updated"
   (annotate-clear-annotations)
   (annotate-load-annotations)
-  (font-lock-flush nil))
+  (font-lock-flush))
 
 (defun annotate-initialize ()
   "Load annotations and set up save and display hooks."

--- a/annotate.el
+++ b/annotate.el
@@ -424,19 +424,19 @@ modified (for example a newline is inserted)."
                (let ((chain (cl-remove overlay (annotate-find-chain overlay))))
                  (delete-overlay overlay)
                  (annotate--remap-chain-pos chain)
-                 (font-lock-fontify-buffer))))))))))
+                 (font-lock-ensure))))))))))
 
 (defun annotate-info-select-fn ()
   "The function to be called when an info buffer is updated"
   (annotate-clear-annotations)
   (annotate-load-annotations)
-  (font-lock-fontify-buffer nil))
+  (font-lock-ensure nil))
 
 (defun annotate-initialize ()
   "Load annotations and set up save and display hooks."
   (annotate-load-annotations)
   (add-hook 'after-save-hook                  'annotate-save-annotations t t)
-  (add-hook 'window-configuration-change-hook 'font-lock-fontify-buffer  t t)
+  (add-hook 'window-configuration-change-hook 'font-lock-ensure  t t)
   (add-hook 'before-change-functions          'annotate-before-change-fn t t)
   (add-hook 'Info-selection-hook              'annotate-info-select-fn   t t)
   (if annotate-use-echo-area
@@ -452,7 +452,7 @@ modified (for example a newline is inserted)."
   "Clear annotations and remove save and display hooks."
   (annotate-clear-annotations)
   (remove-hook 'after-save-hook                  'annotate-save-annotations t)
-  (remove-hook 'window-configuration-change-hook 'font-lock-fontify-buffer  t)
+  (remove-hook 'window-configuration-change-hook 'font-lock-ensure  t)
   (remove-hook 'before-change-functions          'annotate-before-change-fn t)
   (remove-hook 'Info-selection-hook              'annotate-info-select-fn   t)
   (if annotate-use-echo-area
@@ -626,7 +626,7 @@ specified by `from' and `to'."
             (create-new-annotation)))))
        (annotation
         (annotate-change-annotation (point))
-        (font-lock-fontify-buffer nil))
+        (font-lock-ensure nil))
        (t
         (if (annotate--position-on-annotated-text-p (point))
             (signal 'annotate-annotate-region-overlaps nil)
@@ -1384,7 +1384,7 @@ essentially what you get from:
                 (annotation-string  (annotate-annotation-string       annotation)))
             (annotate-create-annotation start end annotation-string)))))
     (set-buffer-modified-p modified-p)
-    (font-lock-fontify-buffer)
+    (font-lock-ensure)
     (if annotate-use-messages
         (message "Annotations loaded."))))
 
@@ -1462,7 +1462,7 @@ example:
                                            annotation-string
                                            annotated-text))))))
         (set-buffer-modified-p modified-p)
-        (font-lock-fontify-buffer)
+        (font-lock-ensure)
         (when annotate-use-messages
           (message "Annotations loaded."))))))
 
@@ -2003,7 +2003,7 @@ This function is not part of the public API."
           (progn ; delete just the last element of the chain
             (annotate-delete-chain-element last-annotation)
             (when refontify-buffer
-              (font-lock-fontify-buffer)))))
+              (font-lock-ensure)))))
        (t
         (move-overlay last-annotation last-annotation-starting-pos new-ending-pos))))))
 

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.1.4
+;; Version: 1.1.5
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/annotate.el
+++ b/annotate.el
@@ -1888,13 +1888,21 @@ See the variable: `annotate-use-echo-area'."
 This function is not part of the public API."
   (annotate-ensure-annotation (annotation)
     (save-excursion
-      (let ((chain (annotate-find-chain annotation)))
-        (dolist (single-element chain)
-          (goto-char (overlay-end single-element))
-          (move-end-of-line nil)
-          (annotate--remove-annotation-property (overlay-start single-element)
-                                                (overlay-end   single-element))
-          (delete-overlay single-element))))))
+      (with-current-buffer (current-buffer)
+        (let* ((chain         (annotate-find-chain annotation))
+               (filename      (annotate-actual-file-name))
+               (info-format-p (eq (annotate-guess-file-format filename)
+                                  :info)))
+          (dolist (single-element chain)
+            (goto-char (overlay-end single-element))
+            (move-end-of-line nil)
+            (when info-format-p
+              (read-only-mode -1))
+            (annotate--remove-annotation-property (overlay-start single-element)
+                                                  (overlay-end   single-element))
+            (delete-overlay single-element)
+            (when info-format-p
+              (read-only-mode 1))))))))
 
 (defun annotate--delete-annotation-chain-ring (annotation-ring)
   "Delete overlay of `annotation-ring' from a buffer.

--- a/annotate.el
+++ b/annotate.el
@@ -626,7 +626,7 @@ specified by `from' and `to'."
             (create-new-annotation)))))
        (annotation
         (annotate-change-annotation (point))
-        (font-lock-flush nil))
+        (font-lock-flush))
        (t
         (if (annotate--position-on-annotated-text-p (point))
             (signal 'annotate-annotate-region-overlaps nil)

--- a/annotate.el
+++ b/annotate.el
@@ -474,6 +474,11 @@ modified (for example a newline is inserted)."
   "Is 'overlay' an annotation?"
   (annotate-overlay-filled-p overlay))
 
+(cl-defmacro annotate-ensure-annotation ((overlay) &body body)
+  "Runs body only if overlay is an annotation (i.e. passes annotationp)"
+  `(and (annotationp ,overlay)
+        (progn ,@body)))
+
 (defun annotate--position-on-annotated-text-p (pos)
   "Does `pos' (as buffer position) corresponds to a character
 that belong to some annotated text?"
@@ -1420,9 +1425,9 @@ example:
 '(\"/foo/bar\" ((0 9 \"note\" \"annotated\")) hash-as-hex-string)
 
 "
+  (interactive)
   (cl-labels ((old-format-p (annotation)
                             (not (stringp (cl-first (last annotation))))))
-    (interactive)
     (let* ((filename             (annotate-actual-file-name))
            (all-annotations-data (annotate-load-annotation-data t))
            (annotation-dump      (assoc-string filename all-annotations-data))
@@ -1636,11 +1641,6 @@ functions).
   "Is the arg an empty string or null?"
   (or (null a)
       (string= "" a)))
-
-(cl-defmacro annotate-ensure-annotation ((overlay) &body body)
-  "Runs body only if overlay is an annotation (i.e. passes annotationp)"
-  `(and (annotationp ,overlay)
-        (progn ,@body)))
 
 (defun annotate-annotation-prop-get (annotation property)
   "Get  property  `property'  from  annotation  `annotation'.  If

--- a/annotate.el
+++ b/annotate.el
@@ -424,19 +424,19 @@ modified (for example a newline is inserted)."
                (let ((chain (cl-remove overlay (annotate-find-chain overlay))))
                  (delete-overlay overlay)
                  (annotate--remap-chain-pos chain)
-                 (font-lock-ensure))))))))))
+                 (font-lock-flush))))))))))
 
 (defun annotate-info-select-fn ()
   "The function to be called when an info buffer is updated"
   (annotate-clear-annotations)
   (annotate-load-annotations)
-  (font-lock-ensure nil))
+  (font-lock-flush nil))
 
 (defun annotate-initialize ()
   "Load annotations and set up save and display hooks."
   (annotate-load-annotations)
   (add-hook 'after-save-hook                  'annotate-save-annotations t t)
-  (add-hook 'window-configuration-change-hook 'font-lock-ensure  t t)
+  (add-hook 'window-configuration-change-hook 'font-lock-flush  t t)
   (add-hook 'before-change-functions          'annotate-before-change-fn t t)
   (add-hook 'Info-selection-hook              'annotate-info-select-fn   t t)
   (if annotate-use-echo-area
@@ -452,7 +452,7 @@ modified (for example a newline is inserted)."
   "Clear annotations and remove save and display hooks."
   (annotate-clear-annotations)
   (remove-hook 'after-save-hook                  'annotate-save-annotations t)
-  (remove-hook 'window-configuration-change-hook 'font-lock-ensure  t)
+  (remove-hook 'window-configuration-change-hook 'font-lock-flush  t)
   (remove-hook 'before-change-functions          'annotate-before-change-fn t)
   (remove-hook 'Info-selection-hook              'annotate-info-select-fn   t)
   (if annotate-use-echo-area
@@ -626,7 +626,7 @@ specified by `from' and `to'."
             (create-new-annotation)))))
        (annotation
         (annotate-change-annotation (point))
-        (font-lock-ensure nil))
+        (font-lock-flush nil))
        (t
         (if (annotate--position-on-annotated-text-p (point))
             (signal 'annotate-annotate-region-overlaps nil)
@@ -1341,7 +1341,7 @@ essentially what you get from:
                 (annotation-string  (annotate-annotation-string       annotation)))
             (annotate-create-annotation start end annotation-string nil)))))
     (set-buffer-modified-p modified-p)
-    (font-lock-ensure)
+    (font-lock-flush)
     (if annotate-use-messages
         (message "Annotations loaded."))))
 
@@ -1419,7 +1419,7 @@ example:
                                            annotation-string
                                            annotated-text))))))
         (set-buffer-modified-p modified-p)
-        (font-lock-ensure)
+        (font-lock-flush)
         (when annotate-use-messages
           (message "Annotations loaded."))))))
 
@@ -1960,7 +1960,7 @@ This function is not part of the public API."
           (progn ; delete just the last element of the chain
             (annotate-delete-chain-element last-annotation)
             (when refontify-buffer
-              (font-lock-ensure)))))
+              (font-lock-flush)))))
        (t
         (move-overlay last-annotation last-annotation-starting-pos new-ending-pos))))))
 

--- a/annotate.el
+++ b/annotate.el
@@ -1195,26 +1195,6 @@ an overlay and it's annotation."
         'insert-in-front-hooks
         '(annotate--remove-annotation-property)))
 
-(defun annotate-context-before (pos)
- "Context lines before POS. Returns nil if we reach a line before
-first line of the buffer"
-  (save-excursion
-    (goto-char pos)
-    (beginning-of-line)
-    (let ((bol (point)))
-      (when (> (1- bol) 0)
-        (beginning-of-line (- (1- annotate-diff-export-context)))
-        (buffer-substring-no-properties (point) (max 1 (1- bol)))))))
-
-(defun annotate-context-after (pos)
-  "Context lines after POS."
-  (save-excursion
-    (goto-char pos)
-    (end-of-line)
-    (let ((eol (point)))
-      (end-of-line (1+ annotate-diff-export-context))
-      (buffer-substring-no-properties (1+ eol) (point)))))
-
 (defun annotate-prefix-lines (prefix text &optional omit-trailing-null)
   "Prepend PREFIX to each line in TEXT."
   (let ((lines (annotate--split-lines text "\n")))
@@ -1224,30 +1204,6 @@ first line of the buffer"
                                                 :from-end t)))
         (setf lines (subseq lines 0 (1+ last-not-empty)))))
     (apply 'concat (mapcar (lambda (l) (concat prefix l "\n")) lines))))
-
-(defun annotate-diff-line-range (start end lines-annotation-text chain-last-p)
-  "Calculate diff-like line range for annotation."
-  (save-excursion
-    (let* ((lines-count       (count-lines (point-min) (point-max)))
-           ;; forward-line move the point, too!
-           (lines-before      (- (- annotate-diff-export-context)
-                                 (forward-line (- annotate-diff-export-context))))
-           ;; because  of  forward-line  above point  has  been  moved
-           ;; 'annotate-diff-export-context'  lines  or at  the  first
-           ;; line of the buffer
-           (start-line        (line-number-at-pos (point)))
-           (diff-offset-start (- (line-number-at-pos start)
-                                 start-line))
-           (diff-offset-end   (min annotate-diff-export-context
-                                   (- lines-count (line-number-at-pos start))))
-           (end-increment     (if chain-last-p
-                                  (+ 2 (length (annotate--split-lines lines-annotation-text)))
-                                2)))
-      (format "-%i,%i +%i,%i"
-              start-line
-              (+ diff-offset-start diff-offset-end 1)
-              start-line
-              (+ diff-offset-start diff-offset-end end-increment)))))
 
 ;;; database related procedures
 

--- a/annotate.el
+++ b/annotate.el
@@ -1338,7 +1338,7 @@ essentially what you get from:
           (let ((start              (annotate-beginning-of-annotation annotation))
                 (end                (annotate-ending-of-annotation    annotation))
                 (annotation-string  (annotate-annotation-string       annotation)))
-            (annotate-create-annotation start end annotation-string)))))
+            (annotate-create-annotation start end annotation-string nil)))))
     (set-buffer-modified-p modified-p)
     (font-lock-ensure)
     (if annotate-use-messages

--- a/annotate.el
+++ b/annotate.el
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.1.4"
+  :version "1.1.5"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -760,9 +760,10 @@ annotate-actual-comment-end"
         (cl-loop
          for buffer-line in buffer-lines
          for line-number from 1  do
-         (let ((overlays-in-line (remove-if-not (lambda (a) (= (annotate-overlay-lines-line a)
-                                                               line-number))
-                                                overlay-relative-pos)))
+         (let ((overlays-in-line (cl-remove-if-not (lambda (a)
+                                                     (= (annotate-overlay-lines-line a)
+                                                        line-number))
+                                                   overlay-relative-pos)))
            (when (or (/= (1- line-number)
                          lines-count)
                      (not (annotate-string-empty-p buffer-line)))
@@ -1202,7 +1203,7 @@ an overlay and it's annotation."
       (let ((last-not-empty (cl-position-if-not 'annotate-string-empty-p
                                                 lines
                                                 :from-end t)))
-        (setf lines (subseq lines 0 (1+ last-not-empty)))))
+        (setf lines (cl-subseq lines 0 (1+ last-not-empty)))))
     (apply 'concat (mapcar (lambda (l) (concat prefix l "\n")) lines))))
 
 ;;; database related procedures


### PR DESCRIPTION
Hi!

After trying to address #97 and the excellent suggestion from Emacs Doom maintainer from https://github.com/hlissner/doom-emacs/issues/4783 i realized i introduced many subtle inconsistencies in the code (and even an actual bug as in #97!).

Fortunately the compiler is smart enough ;-) to recognize some of them and i tried to make it happy removing al the warning (and hopefully resolve #97 as well). :)

Bye!
C.