### PR TITLE
Prevented asking for annotation when trying to annotate a newline character

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,51 @@
+2021-04-23  cage
+
+        * annotate.el:
+	- added checks for 'annotate-use-messages' value when trying to
+        print a message;
+        - replaced 'if' with 'when' when no 'else' branch exists;
+        - ensured all annotations are saved before showing summary window.
+        - fixed indentation;
+        - improved documentation and fixed indentation for a couple of local
+        functions.
+
+
+2021-04-21  cage
+
+        * annotate.el:
+	- added comments to local functions of 'annotate-annotate';
+        - changed behaviour  when user is annotation  a newline character;
+	update an existing annotation on  the line that terminate with the
+	newline the  user is  annotation only  if the  existing annotation
+	spans the whole line.
+
+2021-04-20  cage
+
+        * annotate.el:
+	- skipped saving to database a file with no annotations;
+        - allowed removing (or cutting) annotations when buffer is in
+        read-only mode;
+        - when annotating  a newline, replace annotation if  a single one
+	exists on the line that is going to be annotated.
+
+2021-04-19  cage
+
+        * annotate.el:
+
+	- added feature; when the customizable variable
+	`annotate-endline-annotate-whole-line' is not nil (default t), and
+	the user try to annotate a newline the whole line is annotated
+	instead (or the next if the line is empty).
+	If `annotate-endline-annotate-whole-line' is nil annotating a newline
+	will signal an error.
+
+2021-04-16  cage
+
+        * annotate.el:
+
+	- prevented asking for annotation when trying to annotate a newline
+        character.
+
 2021-03-14  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -198,7 +198,7 @@
   Fixed highlight color  of annotated text that starts  from the first
   character of the buffer's content.
 
-- 2021-02-05 V1.1.5 Bastian Bechtold, cage ::
+- 2021-03-17 V1.1.5 Bastian Bechtold, cage ::
 
   Removed compilation  warnings, one of  the problem highlighted  by a
   warning was actually preventing this package working on Doom Emacs.
@@ -208,3 +208,21 @@
 
   Many thanks  to many people  that helped discovering  and suggesting
   fix for these problems!
+
+- 2021-04-27 V1.2 Bastian Bechtold, cage ::
+
+  New feature. When the customizable variable
+  `annotate-endline-annotate-whole-line' is not nil (default t), and
+  and the user try to annotate a newline the whole line is annotated
+  instead (or the next if the line is empty).
+
+  If the line contains a single annotation that cover all the line
+  annotating the newline Will ask to edit the annotation. If
+  `annotate-endline-annotate-whole-line' is nil annotating a newline
+  will signal an error.
+
+  Also this version generates smaller database as files left with no
+  annotations will not be saved on disk.
+
+  Finally   annotating   read-only    buffers   (especially   deleting
+  annotations) should works without problems.

--- a/README.org
+++ b/README.org
@@ -66,13 +66,24 @@ can take advantage of its packages generated files management.
 ** keybindings
 
 *** ~C-c  C-a~ (function annotate-annotate)
-    creates  a new annotation  for that
+    Creates  a new annotation  for that
     region. With no active region, ~C-c C-a~ will create an annotation for
     the word  under point. If point  is on an annotated  region, ~C-c C-a~
     will edit that annotation instead of  creating a new one. Clearing the
     annotation deletes them.
 
+    If point  is the newline  character and the  customizable variable
+    ~annotate-endline-annotate-whole-line~ is not  nil (default is non
+    nil)  the whole  line is  annotated (or  the next  if the  line is
+    empty).
+
+    If the line contains a single annotation that cover all the line
+    annotating the newline Will ask to edit the annotation. If
+    `annotate-endline-annotate-whole-line' is nil annotating a newline
+    will signal an error.
+
 **** related customizable variable
+     - ~annotate-endline-annotate-whole-line~
      - ~annotate-highlight~;
      - ~annotate-highlight-secondary~;
      - ~annotate-annotation~;

--- a/annotate.el
+++ b/annotate.el
@@ -630,7 +630,9 @@ specified by `from' and `to'."
        (t
         (if (annotate--position-on-annotated-text-p (point))
             (signal 'annotate-annotate-region-overlaps nil)
-          (create-new-annotation))))
+          (let ((char-maybe-newline (char-after)))
+            (when (not (char-equal char-maybe-newline ?\n))
+              (create-new-annotation))))))
       (set-buffer-modified-p t))))
 
 (cl-defun annotate-goto-next-annotation (&key (startingp t))

--- a/annotate.el
+++ b/annotate.el
@@ -732,7 +732,8 @@ specified by `from' and `to'."
                   (progn
                     (goto-char annotation-last-end)
                     (annotate-goto-next-annotation :startingp nil))
-                (message "This is the last annotation.")))
+                (when annotate-use-messages
+                  (message "This is the last annotation."))))
           (let ((next-annotation (annotate-next-annotation-starts (point))))
             (when next-annotation
               (goto-char (overlay-start next-annotation)))))
@@ -754,7 +755,8 @@ specified by `from' and `to'."
                   (progn
                     (goto-char (1- annotation-first-start))
                     (annotate-goto-previous-annotation :startingp nil))
-                (message "This is the first annotation.")))
+                (when annotate-use-messages
+                  (message "This is the first annotation."))))
           (let ((previous-annotation (annotate-previous-annotation-ends (point))))
             (when previous-annotation
               (goto-char (1- (overlay-end previous-annotation))))))
@@ -3071,7 +3073,8 @@ code, always use load files from trusted sources!"
                                 (annotate-mode  1)
                                 (when (not buffer-was-modified-p)
                                   (set-buffer-modified-p nil)))))))
-              (message "Load aborted by the user")))
+              (when annotate-use-messages
+                (message "Load aborted by the user"))))
         (signal 'annotate-db-file-not-found (list new-db))))))
 
 ;; end of switching database

--- a/annotate.el
+++ b/annotate.el
@@ -1405,8 +1405,8 @@ essentially what you get from:
     (annotate-dump-annotation-data (cl-remove-if (lambda (entry)
                                                    (null (annotate-annotations-from-dump entry)))
                                                  all-annotations))
-    (if annotate-use-messages
-        (message "Annotations saved."))))
+    (when annotate-use-messages
+      (message "Annotations saved."))))
 
 (defun annotate-load-annotation-old-format ()
   "Load all annotations from disk in old format."
@@ -1429,8 +1429,8 @@ essentially what you get from:
             (annotate-create-annotation start end annotation-string nil)))))
     (set-buffer-modified-p modified-p)
     (font-lock-flush)
-    (if annotate-use-messages
-        (message "Annotations loaded."))))
+    (when annotate-use-messages
+      (message "Annotations loaded."))))
 
 (defun annotate-load-annotations ()
   "Load all annotations from disk and redraw the buffer to render the annotations.

--- a/annotate.el
+++ b/annotate.el
@@ -629,13 +629,14 @@ specified by `from' and `to'."
                 ;; annotate a line that terminate at `eol'
                 ;;
                 ;; if  the line  contains no  text before  the newline
-                ;; annotate the next line with text, if any
+                ;; annotate the next line with text, if any.
                 ;;
                 ;; if the line contains a single annotation that spans
                 ;; the whole line update the existing annotation
                 ;;
-                ;; if  the line  contains no  annotation annotate  the
-                ;; whole line that terminate at `eol'
+                ;; if the  line contains  no annotation, or  more than
+                ;; one  annotation,  annotate   the  whole  line  that
+                ;; terminate at `eol'
                 (let* ((bol                     (annotate-beginning-of-line-pos))
                        (annotations-on-the-line (annotate-annotations-overlay-in-range bol
                                                                                        eol)))
@@ -2702,29 +2703,29 @@ Arguments:
               ;; filter-fn     see the docstring
               ;; matchp        non nil if (funcall filter-fn previous-token) is not nil
               (operator             (previous-token filter-fn annotation matchp)
-                                    (let ((look-ahead        (annotate-summary-lexer t)))
-                                      (if (annotate-summary-query-parse-end-input-p look-ahead)
-                                          ;; end of input, recurse one more time
-                                          (annotate-summary-query-parse-note filter-fn
-                                                                             annotation
-                                                                             matchp)
-                                        (let ((look-ahead-symbol
-                                               (annotate-summary-query-lexer-symbol look-ahead))
-                                              (look-ahead-string
-                                               (annotate-summary-query-lexer-string look-ahead)))
-                                          (cond
-                                           ((not (cl-find look-ahead-symbol '(and or close-par)))
-                                            (signal 'annotate-query-parsing-error
-                                                    (list (format (concat "Expecting for operator "
-                                                                          "('and' or 'or') or \")\". "
-                                                                          "found %S instead")
-                                                                  look-ahead-string))))
-                                           (t
-                                            ;; found operator, recurse to search for rhs of rule
-                                            ;; NOTE OPERATOR NOTE
-                                            (annotate-summary-query-parse-note filter-fn
-                                                                               annotation
-                                                                               matchp))))))))
+               (let ((look-ahead        (annotate-summary-lexer t)))
+                 (if (annotate-summary-query-parse-end-input-p look-ahead)
+                     ;; end of input, recurse one more time
+                     (annotate-summary-query-parse-note filter-fn
+                                                        annotation
+                                                        matchp)
+                   (let ((look-ahead-symbol
+                          (annotate-summary-query-lexer-symbol look-ahead))
+                         (look-ahead-string
+                          (annotate-summary-query-lexer-string look-ahead)))
+                     (cond
+                      ((not (cl-find look-ahead-symbol '(and or close-par)))
+                       (signal 'annotate-query-parsing-error
+                               (list (format (concat "Expecting for operator "
+                                                     "('and' or 'or') or \")\". "
+                                                     "found %S instead")
+                                             look-ahead-string))))
+                      (t
+                       ;; found operator, recurse to search for rhs of rule
+                       ;; NOTE OPERATOR NOTE
+                       (annotate-summary-query-parse-note filter-fn
+                                                          annotation
+                                                          matchp))))))))
     (let* ((look-ahead (annotate-summary-lexer t))) ; the next token that the lexer *will* consume
                                                     ; note the second arg is non nil
       (if (not (annotate-summary-query-parse-end-input-p look-ahead))

--- a/annotate.el
+++ b/annotate.el
@@ -2482,6 +2482,7 @@ results can be filtered with a simple query language: see
                                (read-from-minibuffer "Query: "))
                               (t
                                ".*"))))
+    (annotate-save-annotations)
     (let* ((filter-query (get-query))
            (dump         (annotate-summary-filter-db (annotate-load-annotation-data t)
                                                      filter-query

--- a/annotate.el
+++ b/annotate.el
@@ -1368,7 +1368,7 @@ essentially what you get from:
       (delete-dups entry))
     ;; skip files with no annotations
     (annotate-dump-annotation-data (cl-remove-if (lambda (entry)
-                                                   (null (cdr entry)))
+                                                   (null (annotate-annotations-from-dump entry)))
                                                  all-annotations))
     (if annotate-use-messages
         (message "Annotations saved."))))

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.1.5
+;; Version: 1.2.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.1.5"
+  :version "1.2.0"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -2490,35 +2490,35 @@ results can be filtered with a simple query language: see
           (when annotate-use-messages
             (message "The annotation database is empty"))
         (with-current-buffer-window
-         annotate-summary-buffer-name nil nil
-         (display-buffer annotate-summary-buffer-name)
-         (select-window (get-buffer-window annotate-summary-buffer-name t))
-         (outline-mode)
-         (use-local-map nil)
-         (local-set-key "q" (lambda ()
-                              (interactive)
-                              (kill-buffer annotate-summary-buffer-name)))
-         (dolist (annotation dump)
-           (let* ((all-annotations (annotate-annotations-from-dump annotation))
-                  (db-filename     (annotate-filename-from-dump annotation)))
-             (when (not (null all-annotations))
-               (insert (format (concat annotate-summary-list-prefix-file "%s\n\n")
-                               db-filename))
-               (dolist (annotation-field all-annotations)
-                 (let* ((button-text      (format "%s"
-                                                  (annotate-annotation-string annotation-field)))
-                        (annotation-begin (annotate-beginning-of-annotation annotation-field))
-                        (annotation-end   (annotate-ending-of-annotation    annotation-field))
-                        (snippet-text     (build-snippet db-filename
-                                                         annotation-begin
-                                                         annotation-end)))
-                   (insert-item-summary db-filename
-                                        snippet-text
-                                        button-text
-                                        annotation-begin
-                                        annotation-end
-                                        filter-query))))))
-         (read-only-mode 1))))))
+            annotate-summary-buffer-name nil nil
+          (display-buffer annotate-summary-buffer-name)
+          (select-window (get-buffer-window annotate-summary-buffer-name t))
+          (outline-mode)
+          (use-local-map nil)
+          (local-set-key "q" (lambda ()
+                               (interactive)
+                               (kill-buffer annotate-summary-buffer-name)))
+          (dolist (annotation dump)
+            (let* ((all-annotations (annotate-annotations-from-dump annotation))
+                   (db-filename     (annotate-filename-from-dump annotation)))
+              (when (not (null all-annotations))
+                (insert (format (concat annotate-summary-list-prefix-file "%s\n\n")
+                                db-filename))
+                (dolist (annotation-field all-annotations)
+                  (let* ((button-text      (format "%s"
+                                                   (annotate-annotation-string annotation-field)))
+                         (annotation-begin (annotate-beginning-of-annotation annotation-field))
+                         (annotation-end   (annotate-ending-of-annotation    annotation-field))
+                         (snippet-text     (build-snippet db-filename
+                                                          annotation-begin
+                                                          annotation-end)))
+                    (insert-item-summary db-filename
+                                         snippet-text
+                                         button-text
+                                         annotation-begin
+                                         annotation-end
+                                         filter-query))))))
+          (read-only-mode 1))))))
 
 ;;;; end summary window procedures
 


### PR DESCRIPTION
Hi!!!

When an user try to annotate an newline (something is not possible to have because of the way the library is designed) the prompt asking for annotation text is shown anyway, even no annotation appears, i found this confusing at best.

I removed the prompt from popup in this case.

Fixes #100 

Bye!!
C.