### PR TITLE
Prevented calling 'annotate--remove-annotation-property' on a narrowed buffer

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,17 @@
+021-04-30  cage
+
+        * annotate.el:
+
+	- prevented calling 'annotate--remove-annotation-property' on a
+	narrowed buffer.
+
+	For some reason (perhaps related to font-locking?) comment-region
+	command was calling this function, the fact is that the command
+	narrows the buffer before actually adding comments, so the call to
+	`point' inside the annotate--remove-annotation-property's body may
+	fall outside of the buffer raising an error. This patch prevents
+	calling this function on narrowed buffer.
+
 2021-04-23  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -226,3 +226,8 @@
 
   Finally   annotating   read-only    buffers   (especially   deleting
   annotations) should works without problems.
+
+- 2021-05-05 V1.2.1 Bastian Bechtold, cage ::
+
+  This version fixes a bug that prevented command like
+  'comment-region' to works properly when annotate-mode was active.

--- a/annotate.el
+++ b/annotate.el
@@ -1228,8 +1228,8 @@ a        a**
 
 (defun annotate--remove-annotation-property (begin end)
   "Cleans up annotation properties associated with a region."
-  (when (> (buffer-size)
-           0)
+  (when (and (> (buffer-size) 0)
+             (not (buffer-narrowed-p)))
     (annotate-with-inhibit-modification-hooks
      (annotate-with-disable-read-only
       ;; copy undo list
@@ -1242,8 +1242,7 @@ a        a**
           ;; annotated newline used to be
           (end-of-line)
           ;; strip dangling display property
-          (remove-text-properties
-           (point) (1+ (point)) '(display nil)))
+          (remove-text-properties (point) (1+ (point)) '(display nil)))
         ;; restore undo list
         (setf buffer-undo-list saved-undo-list)
         (buffer-enable-undo))))))

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.2.0
+;; Version: 1.2.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.2.0"
+  :version "1.2.1"
   :group 'text)
 
 ;;;###autoload


### PR DESCRIPTION
Hi @bastibe !

From the commit message:

``For  some reason  (perhaps related  to font-locking?)   comment-region
command  was calling  this  function,  the fact  is  that the  command
narrows the  buffer before  actually adding comments,  so the  call to
`point'  inside  the annotate--remove-annotation-property's  body  may
fall  outside of  the buffer  raising  an error.  This patch  prevents
calling this function on narrowed buffer.''

This patch should fix #103 and i feel #86 too.

Bye!
C.