### PR TITLE
Prevented saving a file with an empty database;

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,10 @@
-021-04-30  cage
+2021-05-07  cage
+
+        * annotate.el:
+
+	- prevented saving a file with an empty database;
+
+2021-04-30  cage
 
         * annotate.el:
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -231,3 +231,15 @@
 
   This version fixes a bug that prevented command like
   'comment-region' to works properly when annotate-mode was active.
+
+- 2021-05-07 V1.3.0 cage ::
+
+  This version  added a procedure to  prevent an empty database  to be
+  saved on the user's disk.
+
+  Moreover if an  empty annotations database is going  to overwrite an
+  existing stale database file on disk the file is deleted instead.
+
+  Before  deleting the  old database  file a  confirmation message  is
+  printed    on    the    minibuffer   if    the    custom    variable
+  'annotate-database-confirm-deletion' is non nil (default: t).

--- a/README.org
+++ b/README.org
@@ -53,15 +53,19 @@ see:
 [[https://github.com/bastibe/annotate.el/issues/68][this thread]] and, in particular
 [[https://github.com/bastibe/annotate.el/issues/68#issuecomment-728218022][this message]].
 
+If an  empty annotation database  (in memory) is saved  the database
+file  is deleted  instead, if  ~annotate-database-confirm-deletion~ is
+non  nil (the  default) a  confirmation action  is asked  to the  user
+before actually remove the file from the file system.
+
 Users of
 [[https://github.com/emacscollective/no-littering][no-littering]]
 can take advantage of its packages generated files management.
 
 **** related customizable variable
      - ~annotate-file~
-
-**** related customizable variable
      - ~annotate-warn-if-hash-mismatch~
+     - ~annotate-database-confirm-deletion~
 
 ** keybindings
 

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.2.1
+;; Version: 1.3.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.2.1"
+  :version "1.3.0"
   :group 'text)
 
 ;;;###autoload


### PR DESCRIPTION
Hi!

This patch try to address #104.

The general idea is (in function `annotate-dump-annotation-data`) to prevent the annotation file to be saved, or delete it, if the annotation database is empty (i.e. there are not buffers with annotated text when  `annotate-dump-annotation-data` is called).

Bye!
C.