### PR TITLE
Fixed callback for "[replace]" button in summary window

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,26 @@
+2021-05-27  cage
+
+        * annotate.el:
+
+	- fixed annotated text shown in the summary window
+
+	When an annotated buffer (that is  visiting a file) is modified in
+	a way that  changes the position of an annotation  in that buffer,
+	showing the  summary window -without  saving the file  first- will
+	read the  annotation using the  updated position but will  get the
+	contents from the  outdated file; this gives wrong  results in the
+	text  annotation  parts of  the  summary  windows, with  the  text
+	shifted from  the correct  position.  This patch  try to  fix this
+	bug.
+
+2021-05-26  cage
+
+        * annotate.el:
+
+	- fixed  callback for  "[replace]" button  in summary  window; the
+	callback  function  was  neither properly  saving  the  annotation
+	database nor refreshing the buffer's annotations.
+
 2021-05-07  cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -243,3 +243,16 @@
   Before  deleting the  old database  file a  confirmation message  is
   printed    on    the    minibuffer   if    the    custom    variable
   'annotate-database-confirm-deletion' is non nil (default: t).
+
+- 2021-05-27 V1.3.1 cage ::
+
+  Bugfix release:
+
+  - The  button "[replace]"  to edit  an annotation  from the  summary
+    window was not working at all;
+
+  - In certain  cases the  summary window  was rendering  wrong text's
+    fragment instead of the text of the annotation.
+
+  Many thanks  to "glvno"  for reporting  the aforementioned  bugs and
+  testing the patches!

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.3.0
+;; Version: 1.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.3.0"
+  :version "1.3.1"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -2392,20 +2392,23 @@ pressed."
 (cl-defun annotate-wrap-text (text &optional (wrapper "\""))
   (concat wrapper text wrapper))
 
-(cl-defun annotate-unwrap-text (text &optional (wrapper "\""))
-  (let ((left-re  (concat "^" wrapper))
-        (right-re (concat wrapper "$")))
-    (save-match-data
-      (let* ((matchedp      (string-match left-re text))
-             (trimmed-left (if matchedp
-                               (replace-match "" t t text)
-                             text)))
-        (save-match-data
-          (let ((matchedp (string-match right-re trimmed-left)))
-            (if matchedp
-                (replace-match "" t t trimmed-left)
-              trimmed-left)))))))
-
+(cl-defun annotate-unwrap-text (text &optional (wrapper "\"") (left-side t))
+  (let ((results        text)
+        (wrapper-length (length wrapper)))
+    (when (>= (length text)
+              wrapper-length)
+      (if left-side
+          (let ((maybe-wrapper (substring results 0 wrapper-length)))
+            (when (string= maybe-wrapper wrapper)
+              (setf results (substring results wrapper-length))
+              (setf results (annotate-unwrap-text results wrapper nil))))
+        (let ((maybe-wrapper (substring results
+                                        (- (length results)
+                                           wrapper-length))))
+          (when (string= maybe-wrapper wrapper)
+            (setf results (substring results 0 (- (length results)
+                                                  wrapper-length)))))))
+    results))
 
 (cl-defun annotate-show-annotation-summary (&optional arg-query cut-above-point (save-annotations t))
  "Show a summary of all the annotations in a temp buffer, the


### PR DESCRIPTION
Hi! 

The  callback function  was neither  properly saving  the annotation  database nor refreshing the buffer's annotations.

This is a preliminary works to address the first issue reported in #108 .

Bye!
C.