### PR TITLE
Added a command to delete an annotation

### DIFF
--- a/README.org
+++ b/README.org
@@ -94,6 +94,7 @@ can take advantage of its packages generated files management.
 
 **** related customizable variable
      - ~annotate-annotation-column~;
+     - ~annotate-y-or-n-prompt-function~;
      - ~annotate-annotation-confirm-deletion~;
      - ~annotate-annotation-max-size-not-place-new-line~;
      - ~annotate-annotation-position-policy~;
@@ -113,7 +114,7 @@ can take advantage of its packages generated files management.
     annotation.
 
 **** related customizable variable
-     - ~annotate-y-or-n-prompt-function~
+     - ~annotate-y-or-n-prompt-function~;
      - ~annotate-annotation-confirm-deletion~.
 
 *** ~C-c ]~ (function annotate-goto-next-annotation)

--- a/README.org
+++ b/README.org
@@ -22,8 +22,8 @@ is active, ~C-c C-a~ will create, edit, or delete annotations.
 With an  active region, ~C-c  C-a~ creates  a new annotation  for that
 region. With no active region, ~C-c C-a~ will create an annotation for
 the word  under point. If point  is on an annotated  region, ~C-c C-a~
-will edit that annotation instead of  creating a new one. Clearing the
-annotation deletes them.
+will edit that  annotation instead of creating a new  one. Typing ~C-c
+C-d~ or clearing the annotation deletes them.
 
 Use ~C-c ]~ to jump to the next  annotation and ~C-c [~ to jump to the
 previous annotation.
@@ -76,6 +76,10 @@ can take advantage of its packages generated files management.
     will edit that annotation instead of  creating a new one. Clearing the
     annotation deletes them.
 
+    If ~annotate-annotation-confirm-deletion~ is non nil (the default)
+    a confirmation action is asked  to the user before actually remove
+    the annotation.
+
     If point  is the newline  character and the  customizable variable
     ~annotate-endline-annotate-whole-line~ is not  nil (default is non
     nil)  the whole  line is  annotated (or  the next  if the  line is
@@ -87,14 +91,25 @@ can take advantage of its packages generated files management.
     will signal an error.
 
 **** related customizable variable
-     - ~annotate-endline-annotate-whole-line~
-     - ~annotate-highlight~;
-     - ~annotate-highlight-secondary~;
-     - ~annotate-annotation~;
-     - ~annotate-annotation-secondary~;
      - ~annotate-annotation-column~;
+     - ~annotate-annotation-confirm-deletion~;
      - ~annotate-annotation-max-size-not-place-new-line~;
-     - ~annotate-annotation-position-policy~.
+     - ~annotate-annotation-position-policy~;
+     - ~annotate-annotation-secondary~;
+     - ~annotate-annotation~;
+     - ~annotate-endline-annotate-whole-line~;
+     - ~annotate-highlight-secondary~;
+     - ~annotate-highlight~.
+
+*** ~C-c C-d~
+    Delete an annotation under point, if such annotation exists.
+
+    If ~annotate-annotation-confirm-deletion~ is non nil (the default)
+    a confirmation action is asked  to the user before actually remove
+    the annotation.
+
+**** related customizable variable
+     - ~annotate-annotation-confirm-deletion~.
 
 *** ~C-c ]~ (function annotate-goto-next-annotation)
     Jump to the next  annotation.

--- a/README.org
+++ b/README.org
@@ -77,10 +77,8 @@ can take advantage of its packages generated files management.
     annotation deletes them.
 
     If ~annotate-annotation-confirm-deletion~ is  non nil (the default
-    is *nil*) a confirmation action  is asked using the function bound
-    to  the  customizable  variable  ~annotate-y-or-n-prompt-function~
-    (default: ~yes-or-no-p~)  to the  user before actually  remove the
-    annotation.
+    is *nil*) a confirmation action is asked, using ~y-or-n-p~, to the
+    user before actually remove the annotation.
 
     If point  is the newline  character and the  customizable variable
     ~annotate-endline-annotate-whole-line~ is not  nil (default is non
@@ -94,7 +92,6 @@ can take advantage of its packages generated files management.
 
 **** related customizable variable
      - ~annotate-annotation-column~;
-     - ~annotate-y-or-n-prompt-function~;
      - ~annotate-annotation-confirm-deletion~;
      - ~annotate-annotation-max-size-not-place-new-line~;
      - ~annotate-annotation-position-policy~;
@@ -108,13 +105,10 @@ can take advantage of its packages generated files management.
     Delete an annotation under point, if such annotation exists.
 
     If ~annotate-annotation-confirm-deletion~ is  non nil (the default
-    is *nil*) a confirmation action  is asked using the function bound
-    to  the  customizable  variable  ~annotate-y-or-n-prompt-function~
-    (default: ~yes-or-no-p~)  to the  user before actually  remove the
-    annotation.
+    is *nil*) a confirmation action is asked, using ~y-or-n-p~, to the
+    user before actually remove the annotation.
 
 **** related customizable variable
-     - ~annotate-y-or-n-prompt-function~;
      - ~annotate-annotation-confirm-deletion~.
 
 *** ~C-c ]~ (function annotate-goto-next-annotation)

--- a/README.org
+++ b/README.org
@@ -76,9 +76,11 @@ can take advantage of its packages generated files management.
     will edit that annotation instead of  creating a new one. Clearing the
     annotation deletes them.
 
-    If ~annotate-annotation-confirm-deletion~ is non nil (the default)
-    a confirmation action is asked  to the user before actually remove
-    the annotation.
+    If ~annotate-annotation-confirm-deletion~ is  non nil (the default
+    is *nil*) a confirmation action  is asked using the function bound
+    to  the  customizable  variable  ~annotate-y-or-n-prompt-function~
+    (default: ~yes-or-no-p~)  to the  user before actually  remove the
+    annotation.
 
     If point  is the newline  character and the  customizable variable
     ~annotate-endline-annotate-whole-line~ is not  nil (default is non
@@ -104,11 +106,14 @@ can take advantage of its packages generated files management.
 *** ~C-c C-d~
     Delete an annotation under point, if such annotation exists.
 
-    If ~annotate-annotation-confirm-deletion~ is non nil (the default)
-    a confirmation action is asked  to the user before actually remove
-    the annotation.
+    If ~annotate-annotation-confirm-deletion~ is  non nil (the default
+    is *nil*) a confirmation action  is asked using the function bound
+    to  the  customizable  variable  ~annotate-y-or-n-prompt-function~
+    (default: ~yes-or-no-p~)  to the  user before actually  remove the
+    annotation.
 
 **** related customizable variable
+     - ~annotate-y-or-n-prompt-function~
      - ~annotate-annotation-confirm-deletion~.
 
 *** ~C-c ]~ (function annotate-goto-next-annotation)

--- a/annotate.el
+++ b/annotate.el
@@ -2102,7 +2102,8 @@ This function is not part of the public API."
 (defun annotate--confirm-annotation-delete ()
   "Prompt user for delete confirmation.
 This function is not part of the public API."
-  (funcall annotate-y-or-n-prompt-function annotate-confirm-deleting-annotation-prompt))
+  (or (not annotate-annotation-confirm-deletion)
+      (funcall annotate-y-or-n-prompt-function annotate-confirm-deleting-annotation-prompt)))
 
 (cl-defun annotate-delete-annotation (&optional (point (point)))
   "Command  to  delete  an  annotation,  `point'  is  the  buffer

--- a/annotate.el
+++ b/annotate.el
@@ -2108,7 +2108,7 @@ point)."
   (when-let ((annotation (annotate-annotation-at point)))
     (let* ((delete-confirmed-p (annotate--confirm-annotation-delete)))
       (when delete-confirmed-p
-        (annotate--delete-annotation-prevent-modification annotation)))))
+        (annotate--delete-annotation-chain-prevent-modification annotation)))))
 
 (defun annotate-change-annotation (pos)
   "Change annotation at point. If empty, delete annotation."
@@ -2128,7 +2128,7 @@ point)."
          ((string= "" annotation-text)
           (let* ((delete-confirmed-p (annotate--confirm-annotation-delete)))
             (when delete-confirmed-p
-              (annotate--delete-annotation-prevent-modification highlight))))
+              (annotate--delete-annotation-chain-prevent-modification highlight))))
          ;; annotation was changed:
          (t
           (change highlight)))))))

--- a/annotate.el
+++ b/annotate.el
@@ -1995,9 +1995,7 @@ This function is not part of the public API."
    (save-excursion
      (with-current-buffer (current-buffer)
        (let* ((chain         (annotate-find-chain annotation))
-              (filename      (annotate-actual-file-name))
-              (info-format-p (eq (annotate-guess-file-format filename)
-                                 :info)))
+              (filename      (annotate-actual-file-name)))
          (dolist (single-element chain)
            (goto-char (overlay-end single-element))
            (move-end-of-line nil)
@@ -2007,6 +2005,8 @@ This function is not part of the public API."
 
 (defun annotate--delete-annotation-chain-ring (annotation-ring)
   "Delete overlay of `annotation-ring' from a buffer.
+
+A ring is a single element of an annotation chain.
 
 This function is not part of the public API."
   (annotate-ensure-annotation (annotation-ring)
@@ -2018,7 +2018,8 @@ This function is not part of the public API."
       (delete-overlay annotation-ring))))
 
 (defun annotate-delete-chain-element (annotation)
-  "Delete a ring from a chain where `annotation' belong."
+  "Delete a ring (a ring is a single element of an annotation chain.)
+from a chain where `annotation' belong."
   (annotate-ensure-annotation (annotation)
     (let* ((chain                   (annotate-find-chain    annotation))
            (first-of-chain-p        (annotate-chain-first-p annotation))

--- a/annotate.el
+++ b/annotate.el
@@ -219,11 +219,6 @@ by the newline character only) instead."
   :type 'boolean
   :group 'annotate)
 
-(defcustom annotate-y-or-n-prompt-function 'yes-or-no-p
-  "Function to be called when asking user for a yes/no question."
-  :type 'function
-  :group 'annotate)
-
 (defconst annotate-prop-chain-position
   'position)
 
@@ -2103,7 +2098,7 @@ This function is not part of the public API."
   "Prompt user for delete confirmation.
 This function is not part of the public API."
   (or (not annotate-annotation-confirm-deletion)
-      (funcall annotate-y-or-n-prompt-function annotate-confirm-deleting-annotation-prompt)))
+      (y-or-n-p annotate-confirm-deleting-annotation-prompt)))
 
 (cl-defun annotate-delete-annotation (&optional (point (point)))
   "Command  to  delete  an  annotation,  `point'  is  the  buffer

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.3.2
+;; Version: 1.4.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.3.2"
+  :version "1.4.2"
   :group 'text)
 
 ;;;###autoload

--- a/annotate.el
+++ b/annotate.el
@@ -164,7 +164,7 @@ file will be shown."
   :type 'boolean
   :group 'annotate)
 
-(defcustom annotate-annotation-confirm-deletion t
+(defcustom annotate-annotation-confirm-deletion nil
  "If non nil a prompt asking confirmation before deleting an
 annotation file will be shown."
   :type 'boolean

--- a/annotate.el
+++ b/annotate.el
@@ -219,6 +219,11 @@ by the newline character only) instead."
   :type 'boolean
   :group 'annotate)
 
+(defcustom annotate-y-or-n-prompt-function 'yes-or-no-p
+  "Function to be called when asking user for a yes/no question."
+  :type 'function
+  :group 'annotate)
+
 (defconst annotate-prop-chain-position
   'position)
 
@@ -288,6 +293,9 @@ annotation as defined in the database."
 
 (defconst annotate-summary-replace-button-label "[replace]"
   "The label for the button, in summary window, to replace an annotation.")
+
+(defconst annotate-confirm-deleting-annotation-prompt  "Delete this annotation? "
+  "The string for the prompt to be shown when asking for annotation deletion confirm.")
 
 ;;;; custom errors
 
@@ -2094,11 +2102,7 @@ This function is not part of the public API."
 (defun annotate--confirm-annotation-delete ()
   "Prompt user for delete confirmation.
 This function is not part of the public API."
-  (let ((confirm-message "Delete this annotation? [y/N] "))
-    (or (not annotate-annotation-confirm-deletion)
-        (string= (read-from-minibuffer (format confirm-message
-                                               annotate-file))
-                 "y"))))
+  (funcall annotate-y-or-n-prompt-function annotate-confirm-deleting-annotation-prompt))
 
 (cl-defun annotate-delete-annotation (&optional (point (point)))
   "Command  to  delete  an  annotation,  `point'  is  the  buffer


### PR DESCRIPTION
Hi @bastibe !

I have added a new command `C-c C-d` to delete the annotation under the point in a buffer. This is a small patch as the code to build the command was more or less already there! :)

Sorry, i made a mistake and i am using the master branch instead of a custom branch for this pull request. :(

Bye!
C.