### PR TITLE
Fix delete ghost db

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,14 @@
+2021-09-30 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - increased version number.
+        - marked as modified the buffer when an annotation is deleted.
+        - prevented asking to delete a  database that does not actually exists
+        on the file system;
+        - updated NEWS.org;
+
 2021-09-19  cage
 
 	* annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -261,3 +261,17 @@
 
   This  version added  a new  command to  delete the  annotation under
   cursor.
+
+- 2021-09-30 v1.4.3 cage ::
+
+  This  is a bugfix release.
+
+  The  program  would  keep  asking to  confirmation  for  deleting  a
+  database  file even  if such  file does  not actually  exists on  the
+  file system.
+
+  When the  only action on  a buffer  was deleting an  annotation, the
+  buffer was  not marked as  modified; as a consequence,  the deletion
+  would  not happens  on  the  database (the  database  entry for  the
+  annotation to  be deleted would not  be removed from the  file) and,
+  when visiting the file, the annotation would be shown again.

--- a/annotate.el
+++ b/annotate.el
@@ -1584,19 +1584,21 @@ annotation."
 
 (defun annotate-dump-annotation-data (data &optional save-empty-db)
   "Save `data' into annotation file."
-  (if (or save-empty-db
-          data)
-      (with-temp-file annotate-file
-        (let* ((print-length nil)
-               (%abbreviate-filename (lambda (record)
-                                       (let ((full-filename (annotate-filename-from-dump    record))
-                                             (annotations   (annotate-annotations-from-dump record))
-                                             (file-checksum (annotate-checksum-from-dump    record)))
-                                         (annotate-make-record (abbreviate-file-name full-filename)
-                                                               annotations
-                                                               file-checksum))))
-               (actual-data (mapcar %abbreviate-filename data)))
-          (prin1 actual-data (current-buffer))))
+  (cond
+   ((or save-empty-db
+        data)
+    (with-temp-file annotate-file
+      (let* ((print-length nil)
+             (%abbreviate-filename (lambda (record)
+                                     (let ((full-filename (annotate-filename-from-dump    record))
+                                           (annotations   (annotate-annotations-from-dump record))
+                                           (file-checksum (annotate-checksum-from-dump    record)))
+                                       (annotate-make-record (abbreviate-file-name full-filename)
+                                                             annotations
+                                                             file-checksum))))
+             (actual-data (mapcar %abbreviate-filename data)))
+        (prin1 actual-data (current-buffer)))))
+   ((file-exists-p annotate-file)
     (let* ((confirm-message    "Delete annotations database file %S? [y/N] ")
            (delete-confirmed-p (or (not annotate-database-confirm-deletion)
                                    (string= (read-from-minibuffer (format confirm-message
@@ -1607,7 +1609,7 @@ annotation."
               (delete-file annotate-file t)
             (error (message "error removing annotation database: %S"
                             (error-message-string err))))
-        (annotate-dump-annotation-data data t)))))
+        (annotate-dump-annotation-data data t))))))
 
 (cl-defmacro with-matching-annotation-fns ((filename
                                             beginning
@@ -2108,7 +2110,7 @@ point)."
   (when-let ((annotation (annotate-annotation-at point)))
     (let* ((delete-confirmed-p (annotate--confirm-annotation-delete)))
       (when delete-confirmed-p
-        (annotate--delete-annotation-chain-prevent-modification annotation)))))
+        (annotate--delete-annotation-chain annotation)))))
 
 (defun annotate-change-annotation (pos)
   "Change annotation at point. If empty, delete annotation."

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.4.2
+;; Version: 1.4.3
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.4.2"
+  :version "1.4.3"
   :group 'text)
 
 ;;;###autoload


### PR DESCRIPTION
Hi @bastibe !

When an user has no annotation database file on the filesystem and no buffer annotated, the program keeps asking to delete the file that does not exists.

I never noted that bug before because my annotation database is never empty! :-D

Bye!
C.
