### PR TITLE
Patched code as suggested from emacs maintainer.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,50 @@
+2022-02-16 cage
+
+        * annotate.el:
+
+        - removed commented code;
+
+2022-02-12 cage
+
+        * annotate.el:
+
+        - removed nested 'if' inside a call to 'list'.
+
+2022-02-11 cage
+
+        * NEWS.org,
+        * README.org,
+        * annotate.el:
+
+        - improved comment;
+
+        - explained why we need too hook into 'window-configuration-change-hook'
+          and 'annotate-blacklist-major-mode';
+        - commenting  call to  'font-lock-flush' when  removing annotation
+          because there is no more annotated text lef after a deletion;
+        - explained why we need to use 'after-hook';
+        - removed reference in a comment for a non existent argument function;
+        - fixed comment;
+        - flipped order of entries in the news file, now is from more recent
+          to older;
+        - added NonGNU ELPA badge.
+
+2022-02-10 cage
+
+        * annotate.el:
+
+        - fixed typo in docstring;
+        - substituted custom prompt with a call to 'y-or-no-p';
+        - removed   macros    'annotate-with-inhibit-modification-hooks'   and
+         'annotate-with-restore-modified-bit', both  can    be   replaced
+          with 'with-silent-modification'.
+
+2022-02-06 cage
+
+        * annotate.el:
+
+        - patched code as suggested from emacs maintainer.
+
 2022-01-26 cage
 
 	* Changelog,

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,213 +1,55 @@
-- 2015-06-12 V0.1 Bastian Bechtold ::
-  First working release.
+- 2022-01-26 v1.5.0 cage ::
 
-- 2015-06-12 V0.1.1 Bastian Bechtold ::
-  Improve documentation and add license.
+  This version add a new command to import a database file.
 
-- 2015-06-12 V0.1.2 Bastian Bechtold ::
-  Fix typo and version error.
+- 2021-09-30 v1.4.3 cage ::
 
-- 2015-06-15 V0.1.3 Bastian Bechtold ::
-  Improve README and auto-remove empty annotations created by earlier bug.
+  This  is a bugfix release.
 
-- 2015-06-15 V0.1.4 Bastian Bechtold ::
-  Minor bug fixes.
+  The  program  would  keep  asking to  confirmation  for  deleting  a
+  database  file even  if such  file does  not actually  exists on  the
+  file system.
 
-- 2015-06-15 V0.1.5 Bastian Bechtold ::
-  Annotations now work on long lines.
+  When the  only action on  a buffer  was deleting an  annotation, the
+  buffer was  not marked as  modified; as a consequence,  the deletion
+  would  not happens  on  the  database (the  database  entry for  the
+  annotation to  be deleted would not  be removed from the  file) and,
+  when visiting the file, the annotation would be shown again.
 
-- 2015-06-19 V0.2.0 Bastian Bechtold ::
-  Annotations can be exported as unified diff files.
-  Several smaller bug fixes.
+- 2021-09-24 v1.4.2 cage ::
 
-- 2015-06-19 V0.2.1 Bastian Bechtold ::
-  Now with fewer compile warnings (turns out, not really).
+  This  version added  a new  command to  delete the  annotation under
+  cursor.
 
-- 2015-06-19 V0.2.2 Bastian Bechtold ::
-  Now with more compile warnings (0.2.1 didn't work).
+- 2021-05-27 V1.3.1 cage ::
 
-- 2015-07-02 V0.2.3 Bastian Bechtold ::
-  Can now disable minibuffer messages.
+  Bugfix release:
 
-- 2015-09-17 V0.2.4 Bastian Bechtold ::
-  Load and Clear don't mark buffer as modified any more.
+  - The  button "[replace]"  to edit  an annotation  from the  summary
+    window was not working at all;
 
-- 2015-09-21 V0.3.0 Bastian Bechtold ::
-  Add key bindings for jumping to next/previous annotation.
+  - In certain  cases the  summary window  was rendering  wrong text's
+    fragment instead of the text of the annotation.
 
-- 2015-09-22 V0.3.1 Bastian Bechtold ::
-  Change key bindings for jumping as to conform with Emacs' standards.
+  Many thanks  to "glvno"  for reporting  the aforementioned  bugs and
+  testing the patches!
 
-  Didn't change  the main key binding  though, because I don't  know a
-  good alternative.
+- 2021-05-07 V1.3.0 cage ::
 
-- 2015-09-23 V0.4.0 Bastian Bechtold ::
-  Completely reworked the display engine for annotations. You can now
- have several annotations per line, and annotations should not
- move any more when editing the line they are on. Finally,
- annotations can now span several lines.
+  This version  added a procedure to  prevent an empty database  to be
+  saved on the user's disk.
 
-- 2015-10-06 V0.4.3 Bastian Bechtold ::
-  Bugfixes. No more hidden newlines, no more annotations in undo-list,
-  no more error messages with annotations at bol, mark deactivated
-  after creating annotation, annotations auto-reflow on frame size
-  change.
+  Moreover if an  empty annotations database is going  to overwrite an
+  existing stale database file on disk the file is deleted instead.
 
-- 2015-10-06 V0.4.4 Bastian Bechtold ::
-  Added a new export system. Let's see if it turns out to be more
-  useful than the previous one.
+  Before  deleting the  old database  file a  confirmation message  is
+  printed    on    the    minibuffer   if    the    custom    variable
+  'annotate-database-confirm-deletion' is non nil (default: t).
 
-- 2016-08-25 V0.4.5 Bastian Bechtold ::
-  Bugfix release for unicode annotations and multiline annotations.
+- 2021-05-05 V1.2.1 Bastian Bechtold, cage ::
 
-- 2016-09-07 V0.4.6 Bastian Bechtold ::
-  Bugfix release for annotations ending on an empty line.
-
-- 2016-10-06 V0.4.7 Bastian Bechtold ::
-  Bugfix release for buffers without a file name.
-
-- 2019-12-09 V0.5.0 Bastian Bechtold, cage ::
-  - prevented crash when a window (containing annotations) is resized;
-  - prevented loss of undo tree when annotations is modified;
-  - positioning of annotation is customizable;
-  - added a summary window to display annotations; the summary results
-    can be filtered by a simple query language. Deleting or
-    modifying of annotation text is possible;
-  - info files can be annotated (thanks to randomwangran);
-  - annotated text on the same lines are highlighted with two
-    different, alternating, colors;
-  - annotate try to check file modifications using checksum and warns
-    user if the file has been modified when annotate minor mode was
-    not loaded;
-  - a simple heuristic is used to search for annotated text when
-    annotate mode is loaded.
-
-- 2020-01-22 V0.5.1 Bastian Bechtold, cage ::
-  - fixed bug that prevented correct fontifications for major modes
-    that puts overlays on the buffer's text (e.g. SLIME).
-
-- 2020-02-10 V0.5.2 Bastian Bechtold, cage ::
-
-  - fixed bugs that makes some annotations overlaps;
-  - fixed some bugs in fontifications of multiline annotation;
-  - when the only user interactions, before saving, with a visited file was
-    the call of 'annotate-clear-annotations' the annotations
-    will shows again at reload, this should be fixed now.
-
-- 2020-03-06 V0.5.3 Bastian Bechtold, cage ::
-  - Partially fixed bug that prevented annotation of buffer when org-mode was used;
-  - when an user delete an annotation for a file using a button from
-    summary window force refresh of a buffer that is visiting said
-    file, if exists, to reflect the changes;
-  - fixed flowings of annotations when window's width is changed.
-
-- 2020-03-06 V0.6.0 Bastian Bechtold, cage ::
-  Fixed bugs of multiline annotations, diff exports and integration.
-
-- 2020-03-16 V0.6.1 Bastian Bechtold, cage ::
-  Fixed annotation picking in 'annotate-annotate'.
-
-- 2020-03-25 V0.6.2 Bastian Bechtold, cage ::
-  Fixed bug that prevent annotation of text with complex faces definition.
-  Thanks to the person who filed the issue
-  (see: https://github.com/bastibe/annotate.el/pull/63)
-
-- 2020-05-18 V0.7.0 Bastian Bechtold, cage ::
-  Increased version to 0.7.0 for stable release
-
-- 2020-06-09 V0.8.0 Bastian Bechtold, cage ::
-  The database of annotation can be changed using the command ~annotate-switch-db~.
-
-- 2020-06-26 V0.8.1 Bastian Bechtold, cage ::
-  Added file argument to ~annotate-switch-db~.
-
-- 2020-07-01 V0.8.2 Bastian Bechtold, cage ::
-  Added explicit dependency on 'info' and removed a duplicated operation.
-
-- 2020-08-11 V0.8.3 Bastian Bechtold, cage ::
-  Some function now signal errors where appropriate.
-
-- 2020-09-29 V0.9.0 Bastian Bechtold, cage ::
-  Added two new styles to render the annotation: using "pop-up" style
-  or via a specialized summary window.
-
-- 2020-11-20 V0.9.2 Bastian Bechtold, cage ::
-
-  This version fix a regression and  some more bug that could breaks a
-  multiline  annotation  in  ways  that makes  the  annotation  system
-  inconsistent  and  renders the  annotated  text  in wrong  way  (for
-  details see the Changelog).
-
-  The 'annotate-file' can be now  safely declared buffer-local so that
-  multiple databases of annotations can be used on a per-buffer basis.
-
-  For practical applications see:
-
-  https://github.com/bastibe/annotate.el/issues/68
-
-  Many thanks to gopar for spotting  this elusive bug and help testing
-  the patch! :)
-
-- 2020-12-16 V1.0.0 Bastian Bechtold, cage ::
-
-  This version  allow overwrite of notes.  That is, user can  place an
-  annotation on  top of an already  existing one. The new  will delete
-  overlapped portion of the old annotation.
-
-  Also a new  customizable variable ('annotate-warn-if-hash-mismatch')
-  has  been  added.   When  nil   prevent  printing  of  warning  when
-  annotation database's' hash and file has do not match;
-
-  Also a problem with adjacent annotation's coloring has been fixed.
-
-- 2020-12-24 V1.1.0 Bastian Bechtold, cage ::
-
-  This version  improves the  visual style of  annotated text  that if
-  formed by more than one line.
-
-  Also  the file  path  of each  annotated file  (in  the database  of
-  annotation)     is    saved     so    called     abbreviated    form
-  (e.g. '/home/user/foo' is saved as  '~/foo', this could be useful if
-  the database is migrated from one machine to another.
-
-  This  improvements has  been suggested  by  the user  Ran that  also
-  helped testing this new version of the package. Thank you!
-
-  Finally import and export of annotation has been fixed.
-
-  Related to the last  fix the variable ~annotate-diff-export-context~
-  has been removed.
-
-- 2021-01-06 V1.1.1 Bastian Bechtold, cage ::
-
-  This version  fix an old bug  that causes many types  of issues with
-  rendering of annotations on the margin of the window.
-
-- 2021-01-06 V1.1.2 Bastian Bechtold, cage ::
-
-  This  version improves  visual  of multilined  notes  placed on  the
-  window margins.
-
-- 2021-01-06 V1.1.3 Bastian Bechtold, cage ::
-
-  Optimized the code to speedup  reading and saving of encrypted (with
-  GPG) annotated files.
-
-- 2021-02-05 V1.1.4 Bastian Bechtold, cage ::
-
-  Fixed highlight color  of annotated text that starts  from the first
-  character of the buffer's content.
-
-- 2021-03-17 V1.1.5 Bastian Bechtold, cage ::
-
-  Removed compilation  warnings, one of  the problem highlighted  by a
-  warning was actually preventing this package working on Doom Emacs.
-
-  Also a  bug that prevented  annotations placed  on info files  to be
-  deleted has been fixed.
-
-  Many thanks  to many people  that helped discovering  and suggesting
-  fix for these problems!
+  This version fixes a bug that prevented command like
+  'comment-region' to works properly when annotate-mode was active.
 
 - 2021-04-27 V1.2 Bastian Bechtold, cage ::
 
@@ -227,55 +69,216 @@
   Finally   annotating   read-only    buffers   (especially   deleting
   annotations) should works without problems.
 
-- 2021-05-05 V1.2.1 Bastian Bechtold, cage ::
+- 2021-03-17 V1.1.5 Bastian Bechtold, cage ::
 
-  This version fixes a bug that prevented command like
-  'comment-region' to works properly when annotate-mode was active.
+  Removed compilation  warnings, one of  the problem highlighted  by a
+  warning was actually preventing this package working on Doom Emacs.
 
-- 2021-05-07 V1.3.0 cage ::
+  Also a  bug that prevented  annotations placed  on info files  to be
+  deleted has been fixed.
 
-  This version  added a procedure to  prevent an empty database  to be
-  saved on the user's disk.
+  Many thanks  to many people  that helped discovering  and suggesting
+  fix for these problems!
 
-  Moreover if an  empty annotations database is going  to overwrite an
-  existing stale database file on disk the file is deleted instead.
+- 2021-02-05 V1.1.4 Bastian Bechtold, cage ::
 
-  Before  deleting the  old database  file a  confirmation message  is
-  printed    on    the    minibuffer   if    the    custom    variable
-  'annotate-database-confirm-deletion' is non nil (default: t).
+  Fixed highlight color  of annotated text that starts  from the first
+  character of the buffer's content.
 
-- 2021-05-27 V1.3.1 cage ::
+- 2021-01-06 V1.1.3 Bastian Bechtold, cage ::
 
-  Bugfix release:
+  Optimized the code to speedup  reading and saving of encrypted (with
+  GPG) annotated files.
 
-  - The  button "[replace]"  to edit  an annotation  from the  summary
-    window was not working at all;
+- 2021-01-06 V1.1.2 Bastian Bechtold, cage ::
 
-  - In certain  cases the  summary window  was rendering  wrong text's
-    fragment instead of the text of the annotation.
+  This  version improves  visual  of multilined  notes  placed on  the
+  window margins.
 
-  Many thanks  to "glvno"  for reporting  the aforementioned  bugs and
-  testing the patches!
+- 2021-01-06 V1.1.1 Bastian Bechtold, cage ::
 
-- 2021-09-24 v1.4.2 cage ::
+  This version  fix an old bug  that causes many types  of issues with
+  rendering of annotations on the margin of the window.
 
-  This  version added  a new  command to  delete the  annotation under
-  cursor.
+- 2020-12-24 V1.1.0 Bastian Bechtold, cage ::
 
-- 2021-09-30 v1.4.3 cage ::
+  This version  improves the  visual style of  annotated text  that if
+  formed by more than one line.
 
-  This  is a bugfix release.
+  Also  the file  path  of each  annotated file  (in  the database  of
+  annotation)     is    saved     so    called     abbreviated    form
+  (e.g. '/home/user/foo' is saved as  '~/foo', this could be useful if
+  the database is migrated from one machine to another.
 
-  The  program  would  keep  asking to  confirmation  for  deleting  a
-  database  file even  if such  file does  not actually  exists on  the
-  file system.
+  This  improvements has  been suggested  by  the user  Ran that  also
+  helped testing this new version of the package. Thank you!
 
-  When the  only action on  a buffer  was deleting an  annotation, the
-  buffer was  not marked as  modified; as a consequence,  the deletion
-  would  not happens  on  the  database (the  database  entry for  the
-  annotation to  be deleted would not  be removed from the  file) and,
-  when visiting the file, the annotation would be shown again.
+  Finally import and export of annotation has been fixed.
 
-- 2022-01-26 v1.5.0 cage ::
+  Related to the last  fix the variable ~annotate-diff-export-context~
+  has been removed.
 
-  This version add a new command to import a database file.
+- 2020-12-16 V1.0.0 Bastian Bechtold, cage ::
+
+  This version  allow overwrite of notes.  That is, user can  place an
+  annotation on  top of an already  existing one. The new  will delete
+  overlapped portion of the old annotation.
+
+  Also a new  customizable variable ('annotate-warn-if-hash-mismatch')
+  has  been  added.   When  nil   prevent  printing  of  warning  when
+  annotation database's' hash and file has do not match;
+
+  Also a problem with adjacent annotation's coloring has been fixed.
+
+- 2020-11-20 V0.9.2 Bastian Bechtold, cage ::
+
+  This version fix a regression and  some more bug that could breaks a
+  multiline  annotation  in  ways  that makes  the  annotation  system
+  inconsistent  and  renders the  annotated  text  in wrong  way  (for
+  details see the Changelog).
+
+  The 'annotate-file' can be now  safely declared buffer-local so that
+  multiple databases of annotations can be used on a per-buffer basis.
+
+  For practical applications see:
+
+  https://github.com/bastibe/annotate.el/issues/68
+
+  Many thanks to gopar for spotting  this elusive bug and help testing
+  the patch! :)
+
+- 2020-09-29 V0.9.0 Bastian Bechtold, cage ::
+  Added two new styles to render the annotation: using "pop-up" style
+  or via a specialized summary window.
+
+- 2020-08-11 V0.8.3 Bastian Bechtold, cage ::
+  Some function now signal errors where appropriate.
+
+- 2020-07-01 V0.8.2 Bastian Bechtold, cage ::
+  Added explicit dependency on 'info' and removed a duplicated operation.
+
+- 2020-06-26 V0.8.1 Bastian Bechtold, cage ::
+  Added file argument to ~annotate-switch-db~.
+
+- 2020-06-09 V0.8.0 Bastian Bechtold, cage ::
+  The database of annotation can be changed using the command ~annotate-switch-db~.
+
+- 2020-05-18 V0.7.0 Bastian Bechtold, cage ::
+  Increased version to 0.7.0 for stable release
+
+- 2020-03-25 V0.6.2 Bastian Bechtold, cage ::
+  Fixed bug that prevent annotation of text with complex faces definition.
+  Thanks to the person who filed the issue
+  (see: https://github.com/bastibe/annotate.el/pull/63)
+
+- 2020-03-16 V0.6.1 Bastian Bechtold, cage ::
+  Fixed annotation picking in 'annotate-annotate'.
+
+- 2020-03-06 V0.6.0 Bastian Bechtold, cage ::
+  Fixed bugs of multiline annotations, diff exports and integration.
+
+- 2020-03-06 V0.5.3 Bastian Bechtold, cage ::
+  - Partially fixed bug that prevented annotation of buffer when org-mode was used;
+  - when an user delete an annotation for a file using a button from
+    summary window force refresh of a buffer that is visiting said
+    file, if exists, to reflect the changes;
+  - fixed flowings of annotations when window's width is changed.
+
+- 2020-02-10 V0.5.2 Bastian Bechtold, cage ::
+
+  - fixed bugs that makes some annotations overlaps;
+  - fixed some bugs in fontifications of multiline annotation;
+  - when the only user interactions, before saving, with a visited file was
+    the call of 'annotate-clear-annotations' the annotations
+    will shows again at reload, this should be fixed now.
+
+- 2020-01-22 V0.5.1 Bastian Bechtold, cage ::
+  - fixed bug that prevented correct fontifications for major modes
+    that puts overlays on the buffer's text (e.g. SLIME).
+
+- 2019-12-09 V0.5.0 Bastian Bechtold, cage ::
+  - prevented crash when a window (containing annotations) is resized;
+  - prevented loss of undo tree when annotations is modified;
+  - positioning of annotation is customizable;
+  - added a summary window to display annotations; the summary results
+    can be filtered by a simple query language. Deleting or
+    modifying of annotation text is possible;
+  - info files can be annotated (thanks to randomwangran);
+  - annotated text on the same lines are highlighted with two
+    different, alternating, colors;
+  - annotate try to check file modifications using checksum and warns
+    user if the file has been modified when annotate minor mode was
+    not loaded;
+  - a simple heuristic is used to search for annotated text when
+    annotate mode is loaded.
+
+- 2016-10-06 V0.4.7 Bastian Bechtold ::
+  Bugfix release for buffers without a file name.
+
+- 2016-09-07 V0.4.6 Bastian Bechtold ::
+  Bugfix release for annotations ending on an empty line.
+
+- 2016-08-25 V0.4.5 Bastian Bechtold ::
+  Bugfix release for unicode annotations and multiline annotations.
+
+- 2015-10-06 V0.4.4 Bastian Bechtold ::
+  Added a new export system. Let's see if it turns out to be more
+  useful than the previous one.
+
+- 2015-10-06 V0.4.3 Bastian Bechtold ::
+  Bugfixes. No more hidden newlines, no more annotations in undo-list,
+  no more error messages with annotations at bol, mark deactivated
+  after creating annotation, annotations auto-reflow on frame size
+  change.
+
+- 2015-09-23 V0.4.0 Bastian Bechtold ::
+  Completely reworked the display engine for annotations. You can now
+  have several annotations per line, and annotations should not
+  move any more when editing the line they are on. Finally,
+  annotations can now span several lines.
+
+- 2015-09-22 V0.3.1 Bastian Bechtold ::
+  Change key bindings for jumping as to conform with Emacs' standards.
+
+  Didn't change  the main key binding  though, because I don't  know a
+  good alternative.
+
+- 2015-09-21 V0.3.0 Bastian Bechtold ::
+  Add key bindings for jumping to next/previous annotation.
+
+- 2015-09-17 V0.2.4 Bastian Bechtold ::
+  Load and Clear don't mark buffer as modified any more.
+
+- 2015-07-02 V0.2.3 Bastian Bechtold ::
+  Can now disable minibuffer messages.
+
+- 2015-06-19 V0.2.2 Bastian Bechtold ::
+  Now with more compile warnings (0.2.1 didn't work).
+
+- 2015-06-19 V0.2.1 Bastian Bechtold ::
+  Now with fewer compile warnings (turns out, not really).
+
+- 2015-06-19 V0.2.0 Bastian Bechtold ::
+  Annotations can be exported as unified diff files.
+  Several smaller bug fixes.
+
+- 2015-06-15 V0.1.5 Bastian Bechtold ::
+  Annotations now work on long lines.
+
+- 2015-06-15 V0.1.4 Bastian Bechtold ::
+  Minor bug fixes.
+
+- 2015-06-15 V0.1.3 Bastian Bechtold ::
+  Improve README and auto-remove empty annotations created by earlier bug.
+
+- 2015-06-12 V0.1.2 Bastian Bechtold ::
+  Fix typo and version error.
+
+- 2015-06-12 V0.1.1 Bastian Bechtold ::
+  Improve documentation and add license.
+
+- 2015-06-12 V0.1.1 Bastian Bechtold ::
+  Improve documentation and add license.
+
+- 2015-06-12 V0.1 Bastian Bechtold ::
+  First working release.

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,9 @@
+- 2022-01-26 v1.5.1 cage ::
+
+  This version refactored  a lot of code thanks to  the suggestions of
+  Emacs  maintainer. Several  unused variables  were removed  and some
+  portion of the code was simplified.
+
 - 2022-01-26 v1.5.0 cage ::
 
   This version add a new command to import a database file.

--- a/README.org
+++ b/README.org
@@ -2,6 +2,8 @@
 #+AUTHOR:
 #+TITLE: Annotate.el
 
+[[https://elpa.nongnu.org/nongnu/annotate.svg][https://elpa.nongnu.org/nongnu/annotate.svg]]
+
 [[http://melpa.org/#/annotate][http://melpa.org/packages/annotate-badge.svg]]
 
 [[http://stable.melpa.org/#/annotate][http://stable.melpa.org/packages/annotate-badge.svg]]

--- a/annotate.el
+++ b/annotate.el
@@ -2799,12 +2799,10 @@ Arguments:
                 (annotate-summary-token-symbol-match looking-symbol token))
               ;; this function will parse the rule operator
               ;; OPERATOR   := AND | OR
-              ;; where
-              ;; previous-token is the value of the token just matched in rule
               ;; NOTE OPERATOR NOTE
               ;; filter-fn     see the docstring
               ;; matchp        non nil if (funcall filter-fn previous-token) is not nil
-              (operator             (filter-fn annotation matchp)
+              (operator (filter-fn annotation matchp)
                (let ((look-ahead        (annotate-summary-lexer t)))
                  (if (annotate-summary-query-parse-end-input-p look-ahead)
                      ;; end of input, recurse one more time

--- a/annotate.el
+++ b/annotate.el
@@ -1610,11 +1610,9 @@ annotation."
              (actual-data (mapcar %abbreviate-filename data)))
         (prin1 actual-data (current-buffer)))))
    ((file-exists-p annotate-file)
-    (let* ((confirm-message    "Delete annotations database file %S? [y/N] ")
+    (let* ((confirm-message    "Delete annotations database file %S? ")
            (delete-confirmed-p (or (not annotate-database-confirm-deletion)
-                                   (string= (read-from-minibuffer (format confirm-message
-                                                                           annotate-file))
-                                            "y"))))
+                                   (y-or-n-p (format confirm-message annotate-file)))))
       (if delete-confirmed-p
           (condition-case err
               (delete-file annotate-file t)
@@ -3166,12 +3164,9 @@ code, always use load files from trusted sources!"
                     (read-file-name "Database file location: "))))
     (when (not (annotate-string-empty-p new-db))
       (if (file-exists-p new-db)
-          (let* ((confirm-message "Loading elisp file from untrusted source may results in severe security problems. Load %S? [y/N] ")
-                 (load-file-confirmed (if force-load
-                                          t
-                                        (string= (read-from-minibuffer (format confirm-message
-                                                                               new-db))
-                                                 "y"))))
+          (let* ((confirm-message "Loading elisp file from untrusted source may results in severe security problems. Load %S?")
+                 (load-file-confirmed (or force-load
+                                          (y-or-n-p (format confirm-message new-db)))))
             (if load-file-confirmed
                 (progn
                   (setf annotate-file new-db)
@@ -3294,14 +3289,9 @@ their personal database."
                                    (file-exists-p filename)))
                                annotations)))
   (let* ((confirm-message    (concat "Importing databases from untrusted source may cause severe "
-                                     "security issues, continue? [y/N] "))
+                                     "security issues, continue?"))
          (import-confirmed-p (or (not annotate-database-confirm-import)
-                                 ;; FIXME: There's no `%s' in `confirm-message'
-                                 ;; to make use of the `annotate-file' arg?
-                                 ;; FIXME: Use `y-or-n-p' or `yes-or-no-p'!
-                                 (string= (read-string (format confirm-message
-                                                                        annotate-file))
-                                          "y"))))
+                                 (y-or-n-p confirm-message))))
     (when import-confirmed-p
       (let* ((imported-db-name (read-file-name "Choose the database to import: "))
              (imported-db      (remove-non-existing-files (deserialize-db imported-db-name)))

--- a/annotate.el
+++ b/annotate.el
@@ -2390,8 +2390,6 @@ pressed."
   (let* ((filename        (button-get button 'file))
          (beginning       (button-get button 'beginning))
          (ending          (button-get button 'ending))
-         ;; (begin-of-button (button-get button 'begin-of-button))
-         ;; (end-of-button   (button-get button 'end-of-button))
          (db              (annotate-load-annotation-data t))
          (filtered        (annotate-db-remove-annotation db filename beginning ending)))
     (annotate-dump-annotation-data filtered) ; save the new database with entry removed

--- a/annotate.el
+++ b/annotate.el
@@ -427,7 +427,6 @@ modified (for example a newline is inserted)."
                (let ((chain (cl-remove overlay (annotate-find-chain overlay))))
                  (delete-overlay overlay)
                  (annotate--remap-chain-pos chain))))))))))
-;;                 (font-lock-flush))))))))))
 
 (defun annotate-info-select-fn ()
   "The function to be called when an info buffer is updated."
@@ -981,7 +980,6 @@ to `MAXIMUM-WIDTH'."
                         (let* ((potential-start (join-until-width words))
                                (word            (annotate-group-start-word potential-start))
                                (nonjoined-words (annotate-group-words potential-start))
-                               ;; (next-word       (cl-first nonjoined-words))
                                (rest-words      nonjoined-words)
                                (potential-start word))
                           (%group rest-words
@@ -1861,8 +1859,7 @@ The searched interval can be customized setting the variable:
 'annotate-search-region-lines-delta'."
   (cl-labels ((create-annotation (start end annotation-text)
                (save-excursion
-                 (let (;; (chain-pos 0)
-                       (all-overlays ()))
+                 (let ((all-overlays ()))
                    (while (< start end)
                      (goto-char start)
                      (let ((char-maybe-newline (string (char-after))))
@@ -2008,9 +2005,8 @@ This function is not part of the public API."
   (annotate-ensure-annotation (annotation)
    (save-excursion
      (with-current-buffer (current-buffer)
-       (let* ((chain         (annotate-find-chain annotation))
+       (let* ((chain (annotate-find-chain annotation)))
               ;; (filename      (annotate-actual-file-name))
-              )
          (dolist (single-element chain)
            (goto-char (overlay-end single-element))
            (move-end-of-line nil)

--- a/annotate.el
+++ b/annotate.el
@@ -1381,16 +1381,15 @@ essentially what you get from:
   (list left-limit right-limit))
 
 (defun annotate-annotation-interval (annotation)
-  ;; FIXME: Should "interval i the" below be "interval in the"?
   "Return the limits where ANNOTATION is applied.
 The limit is a list of two numbers (LEFT RIGHT) representing of the portion
 of the buffer where this annotation is applied.
 Note that this function returns the character interval
 yyyyyyyy ggg
-  ^^^^^^^  ← Annotation interval i the database (extends for one more than the last character)
+  ^^^^^^^  ← Annotation interval in the database (extends for one more than the last character)
   |----|   ← The interval that this function returns.
 
-In other terms the interval i the database is a closed interval while the interval that
+In other terms the interval in the database is a closed interval while the interval that
 this function return is closed on the left and open on the right side."
   (annotate--make-interval (annotate-beginning-of-annotation annotation)
                            (1- (annotate-ending-of-annotation annotation))))

--- a/annotate.el
+++ b/annotate.el
@@ -423,9 +423,8 @@ modified (for example a newline is inserted)."
              (when (<= a start-overlay)
                (let ((chain (cl-remove overlay (annotate-find-chain overlay))))
                  (delete-overlay overlay)
-                 (annotate--remap-chain-pos chain)
-                 ;; FIXME: Why?  And especially, why the whole buffer?
-                 (font-lock-flush))))))))))
+                 (annotate--remap-chain-pos chain))))))))))
+;;                 (font-lock-flush))))))))))
 
 (defun annotate-info-select-fn ()
   "The function to be called when an info buffer is updated."

--- a/annotate.el
+++ b/annotate.el
@@ -1,4 +1,4 @@
-;;; annotate.el --- annotate files without changing them
+;;; annotate.el --- annotate files without changing them  -*- lexical-binding: t; -*-
 ;; Copyright (C) 2015 Bastian Bechtold and contributors:
 ;; Naoya Yamashita (2018)
 ;; Universita' degli Studi di Palermo (2019)
@@ -61,127 +61,108 @@
   :version "1.5.0"
   :group 'text)
 
+(defvar annotate-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-a") #'annotate-annotate)
+    (define-key map (kbd "C-c C-d") #'annotate-delete-annotation)
+    (define-key map (kbd "C-c C-s") #'annotate-show-annotation-summary)
+    (define-key map (kbd "C-c ]")   #'annotate-goto-next-annotation)
+    (define-key map (kbd "C-c [")   #'annotate-goto-previous-annotation)
+    map))
+
 ;;;###autoload
 (define-minor-mode annotate-mode
   "Toggle Annotate mode.
 See https://github.com/bastibe/annotate.el/ for documentation."
-  :init-value nil
   :lighter " Ann"
-  :keymap (make-sparse-keymap)
   :group 'annotate
+  ;; FIXME: Why `:after-hook'?
   :after-hook (annotate-initialize-maybe))
-
-(define-key annotate-mode-map (kbd "C-c C-a") 'annotate-annotate)
-
-(define-key annotate-mode-map (kbd "C-c C-d") 'annotate-delete-annotation)
-
-(define-key annotate-mode-map (kbd "C-c C-s") 'annotate-show-annotation-summary)
-
-(define-key annotate-mode-map (kbd "C-c ]") 'annotate-goto-next-annotation)
-
-(define-key annotate-mode-map (kbd "C-c [") 'annotate-goto-previous-annotation)
 
 (defcustom annotate-file (locate-user-emacs-file "annotations" ".annotations")
   "File where annotations are stored."
-  :type 'file
-  :group 'annotate)
+  :type 'file)
 
 (defface annotate-highlight
   '((t (:underline "coral")))
-  "Face for annotation highlights."
-  :group 'annotate)
+  "Face for annotation highlights.")
 
 (defface annotate-highlight-secondary
   '((t (:underline "khaki")))
-  "Face for secondary annotation highlights."
-  :group 'annotate)
+  "Face for secondary annotation highlights.")
 
 (defface annotate-annotation
   '((t (:background "coral" :foreground "black" :inherit default)))
-  "Face for annotations."
-  :group 'annotate)
+  "Face for annotations.")
 
 (defface annotate-annotation-secondary
   '((t (:background "khaki" :foreground "black" :inherit default)))
-  "Face for secondary annotations."
-  :group 'annotate)
+  "Face for secondary annotations.")
 
 (defface annotate-prefix
   '((t (:inherit default)))
  "Face for character used to pad annotation (fill space between
-text lines and annotation text)."
- :group 'annotate)
+text lines and annotation text).")
 
 (defcustom annotate-annotation-column 85
   "Where annotations appear."
-  :type 'number
-  :group 'annotate)
+  :type 'number)
 
 (defcustom annotate-diff-export-options ""
  "Other options for diffing between a buffer with and without integrated annotations.
 Note that there is an implicit -u at the end of default options
 that Emacs passes to the diff program."
-  :type 'string
-  :group 'annotate)
+  :type 'string)
 
 (defcustom annotate-use-messages t
   "Whether status messages may appear in the minibuffer."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-integrate-marker " ANNOTATION: "
   "Marker that is written before every integrated annotation."
-  :type 'string
-  :group 'annotate)
+  :type 'string)
 
 (defcustom annotate-integrate-higlight ?~
   "Character used to underline an annotated text."
-  :type 'character
-  :group 'annotate)
+  :type 'character)
 
 (defcustom annotate-fallback-comment "#"
   "When variable `COMMENT-START' is nil use this string instead."
-  :type 'string
-  :group 'annotate)
+  :type 'string)
 
 (defcustom annotate-blacklist-major-mode '()
+  ;; FIXME: When/why would this be needed?
   "Prevent loading of annotate-mode When the visited file's
 major mode is a member of this list (space separated entries)."
-  :type  '(repeat symbol)
-  :group 'annotate)
+  :type  '(repeat symbol))
 
 (defcustom annotate-summary-ask-query t
  "If non nil a prompt asking for a query to filter the database
 before showing it in a summary window is used. If nil the
 database is not filtered at all."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-database-confirm-deletion t
  "If non nil a prompt asking confirmation before deleting a
 database file that is going to be empty after saving an annotated
 file will be shown."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-annotation-confirm-deletion nil
  "If non nil a prompt asking confirmation before deleting an
 annotation file will be shown."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-database-confirm-import t
  "If non nil a prompt asking confirmation before importing a
 database file will be shown."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-annotation-max-size-not-place-new-line 15
  "The maximum 'string-width' allowed for an annotation to be
 placed on the right margin of the window instead of its own line
  after the annotated text."
-  :type  'number
-  :group 'annotate)
+  :type  'number)
 
 (defcustom annotate-annotation-position-policy :by-length
   "Policy for annotation's position:
@@ -196,15 +177,13 @@ if the length is more than the value of
 `ANNOTATE-ANNOTATION-MAX-SIZE-NOT-PLACE-NEW-LINE' place the
 annotation on a new line, place on the right margin
 otherwise."
-  :type  'symbol
-  :group 'annotate)
+  :type  'symbol)
 
 (defcustom annotate-use-echo-area nil
  "Whether annotation text should appear in the echo area only when mouse
 id positioned over the annotated text instead of positioning them in
 the the buffer (the default)."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-warn-if-hash-mismatch t
  "Whether a warning message should be printed if a mismatch
@@ -215,15 +194,13 @@ file.
 This usually happens if an annotated file (a file with an entry in the
 database) is saved with annotated-mode *not* active or the file
 has been modified outside Emacs."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defcustom annotate-endline-annotate-whole-line t
  "Whether trying to annotate the end of line character will
 annotate the whole line before (or after if the line is composed
 by the newline character only) instead."
-  :type 'boolean
-  :group 'annotate)
+  :type 'boolean)
 
 (defconst annotate-prop-chain-position
   'position)
@@ -265,8 +242,7 @@ database the software looks for annotated text in the region with
 delta equals to the value of this variable. Units are in number
 of lines. The center of the region is the position of the
 annotation as defined in the database."
-  :type 'number
-  :group 'annotate)
+  :type 'number)
 
 (defconst annotate-summary-list-prefix "    "
   "The string used as prefix for each text annotation item in summary window.")
@@ -296,7 +272,7 @@ annotation as defined in the database."
   "The label for the button, in summary window, to replace an annotation.")
 
 (defconst annotate-confirm-deleting-annotation-prompt  "Delete this annotation? "
-  "The string for the prompt to be shown when asking for annotation deletion confirm.")
+  "Prompt to be shown when asking for annotation deletion confirm.")
 
 ;;;; custom errors
 
@@ -335,10 +311,10 @@ annotation as defined in the database."
               (overlays-in 0 (buffer-size))))
 
 (defun annotate-initialize-maybe ()
-  "Initialize annotate mode only if buffer's major mode is not in the blacklist (see:
-'annotate-blacklist-major-mode'."
+  "Initialize annotate mode only if buffer's major mode is not in the blacklist.
+See 'annotate-blacklist-major-mode'."
   (let ((annotate-allowed-p (with-current-buffer (current-buffer)
-                              (not (cl-member major-mode annotate-blacklist-major-mode)))))
+                              (not (apply #'derived-mode-p annotate-blacklist-major-mode)))))
     (cond
      ((not annotate-allowed-p)
       (annotate-shutdown)
@@ -354,22 +330,19 @@ annotation as defined in the database."
   (secure-hash 'md5 object))
 
 (cl-defmacro annotate-with-inhibit-modification-hooks (&rest body)
+  ;; FIXME: Use `with-silent-modifications' instead?
   "Wrap `BODY' in a block with modification-hooks inhibited."
-  (let ((old-mode (gensym)))
-    `(let ((,old-mode inhibit-modification-hooks))
-       (unwind-protect
-           (progn
-             (setf inhibit-modification-hooks t)
-             ,@body)
-         (setf inhibit-modification-hooks ,old-mode)))))
+  `(let ((inhibit-modification-hooks t))
+     ,@body))
 
 (cl-defmacro annotate-with-restore-modified-bit (&rest body)
   "Save the value of `BUFFER-MODIFIED-P' before `BODY' is executed
 and restore the saved value just after the end of `BODY'."
+  ;; FIXME: Use `with-silent-modifications' instead?
   (let ((modifiedp (gensym)))
     `(let ((,modifiedp (buffer-modified-p)))
        ,@body
-       (set-buffer-modified-p ,modifiedp))))
+       (restore-buffer-modified-p ,modifiedp))))
 
 (defun annotate-end-of-line-pos ()
  "Get the position of the end of line and rewind the point's
@@ -439,7 +412,7 @@ belong."
       (when last-element
         (annotate-annotation-set-chain-last last-element))))))
 
-(defun annotate-before-change-fn (a b)
+(defun annotate-before-change-fn (a _b)
   "This function is added to 'before-change-functions' hook and
 it is called any time the buffer content is changed (so, for
 example, text is added or deleted). In particular, it will
@@ -449,7 +422,7 @@ modified (for example a newline is inserted)."
    (save-excursion
      (let* ((bol (annotate-beginning-of-line-pos))
             (eol (annotate-end-of-line-pos))
-            (ov  (cl-remove-if-not 'annotationp
+            (ov  (cl-remove-if-not #'annotationp
                                    (overlays-in bol eol))))
        (dolist (overlay ov)
          (annotate--remove-annotation-property (overlay-start overlay)
@@ -464,6 +437,7 @@ modified (for example a newline is inserted)."
                (let ((chain (cl-remove overlay (annotate-find-chain overlay))))
                  (delete-overlay overlay)
                  (annotate--remap-chain-pos chain)
+                 ;; FIXME: Why?  And especially, why the whole buffer?
                  (font-lock-flush))))))))))
 
 (defun annotate-info-select-fn ()
@@ -475,10 +449,10 @@ modified (for example a newline is inserted)."
 (defun annotate-initialize ()
   "Load annotations and set up save and display hooks."
   (annotate-load-annotations)
-  (add-hook 'after-save-hook                  'annotate-save-annotations t t)
-  (add-hook 'window-configuration-change-hook 'font-lock-flush  t t)
-  (add-hook 'before-change-functions          'annotate-before-change-fn t t)
-  (add-hook 'Info-selection-hook              'annotate-info-select-fn   t t)
+  (add-hook 'after-save-hook                  #'annotate-save-annotations t t)
+  (add-hook 'window-configuration-change-hook #'font-lock-flush  t t) ;FIXME: Why?
+  (add-hook 'before-change-functions          #'annotate-before-change-fn t t)
+  (add-hook 'Info-selection-hook              #'annotate-info-select-fn   t t)
   (if annotate-use-echo-area
       (font-lock-add-keywords
        nil
@@ -491,10 +465,10 @@ modified (for example a newline is inserted)."
 (defun annotate-shutdown ()
   "Clear annotations and remove save and display hooks."
   (annotate-clear-annotations)
-  (remove-hook 'after-save-hook                  'annotate-save-annotations t)
-  (remove-hook 'window-configuration-change-hook 'font-lock-flush  t)
-  (remove-hook 'before-change-functions          'annotate-before-change-fn t)
-  (remove-hook 'Info-selection-hook              'annotate-info-select-fn   t)
+  (remove-hook 'after-save-hook                  #'annotate-save-annotations t)
+  (remove-hook 'window-configuration-change-hook #'font-lock-flush  t)
+  (remove-hook 'before-change-functions          #'annotate-before-change-fn t)
+  (remove-hook 'Info-selection-hook              #'annotate-info-select-fn   t)
   (if annotate-use-echo-area
       (font-lock-remove-keywords
        nil
@@ -594,7 +568,7 @@ specified by `FROM' and `TO'."
                (cl-destructuring-bind (start end)
                    (annotate-bounds)
                  (let ((annotation-text (read-from-minibuffer annotate-annotation-prompt)))
-                   (condition-case error-message
+                   (condition-case nil
                        (annotate-create-annotation start end annotation-text nil)
                      (annotate-empty-annotation-text-error
                       (user-error "Annotation text is empty"))))))
@@ -619,7 +593,7 @@ specified by `FROM' and `TO'."
                       (annotate--cut-right-annotation first-of-chain-to-cut t)))
                   (when delete-enclosed
                     (annotate-delete-chains-in-region chain-end region-stop))))
-              (cut-left (region-beg region-stop &optional delete-enclosed)
+              (cut-left (region-stop delete-enclosed)
                 ;; This function will trim on the left one or more
                 ;; existing chains of overlays that compose an
                 ;; annotation (i.e. the overlays applied on the
@@ -694,10 +668,9 @@ specified by `FROM' and `TO'."
               (if (eq starting-chain-at-start
                       starting-chain-at-end)
                   (signal 'annotate-annotate-region-overlaps nil)
-                (let ((start-pos-last-annotation (overlay-start starting-chain-at-end)))
-                  (cut-left start-pos-last-annotation region-stop nil)
-                  (cut-right region-beg region-stop t)
-                  (create-new-annotation)))))
+                (cut-left region-stop nil)
+                (cut-right region-beg region-stop t)
+                (create-new-annotation))))
            ((annotate--position-on-annotated-text-p region-beg)
             ;; aaaabbcc**********
             ;;   ^------------^
@@ -706,7 +679,7 @@ specified by `FROM' and `TO'."
            ((annotate--position-on-annotated-text-p region-stop)
             ;; **********cccaaaa
             ;;   ^------------^
-            (cut-left region-beg region-stop t)
+            (cut-left region-stop t)
             (create-new-annotation))
            (enclosed-chains
             ;; ****aaaaaaaaaaaaaaa****
@@ -917,17 +890,16 @@ An example might look like this:"
   "Export all annotations as a unified diff file.
 An example might look like this:
 
---- /home/bastibe/Projects/annotate.el/annotate.el	2015-06-19 15:13:36.718796738 +0200
-+++ /home/bastibe/Projects/annotate.el/annotate.el	2015-06-19 15:13:36.718796738 +0200
+--- .../annotate.el/annotate.el	2015-06-19 15:13:36.718796738 +0200
++++ .../annotate.el/annotate.el	2015-06-19 15:13:36.718796738 +0200
 @@ -73,5 +73,5 @@
  ;;;###autoload
  (defface annotate-highlight
--  '((t (:underline \"coral\")))
-+  '((t (:underline \"coral\")))
+-  '((t (:underline \"coral\"))))
++  '((t (:underline \"coral\"))))
 #        ~~~~~~~~~~~~~~~~~~
 #        this doesn't work in cli
-   \"Face for annotation highlights.\"
-   :group 'annotate)
+   \"Face for annotation highlights.\")
 
 This diff does not contain any changes, but highlights the
 annotation, and can be conveniently viewed in diff-mode."
@@ -1016,7 +988,7 @@ to `MAXIMUM-WIDTH'."
                         (let* ((potential-start (join-until-width words))
                                (word            (annotate-group-start-word potential-start))
                                (nonjoined-words (annotate-group-words potential-start))
-                               (next-word       (cl-first nonjoined-words))
+                               ;; (next-word       (cl-first nonjoined-words))
                                (rest-words      nonjoined-words)
                                (potential-start word))
                           (%group rest-words
@@ -1047,7 +1019,7 @@ to `MAXIMUM-WIDTH'."
         grouped))))
 
 (cl-defun annotate-safe-subseq (seq from to &optional (value-if-limits-invalid seq))
-  "Returns a substring of `SEQ' or `VALUE-IF-LIMITS-INVALID'
+  "Return a substring of `SEQ' or `VALUE-IF-LIMITS-INVALID'
 sequence if `FROM' or `TO' are invalids."
   (cond
    ((< to from)
@@ -1098,7 +1070,7 @@ sequence if `FROM' or `TO' are invalids."
                      (list (pad last-line max-width nil)))))))
 
 (cl-defun annotate--split-lines (text &optional (separator "\n"))
-  "Returns `TEXT' splitted by `SEPARATOR' (default: \"\n\")."
+  "Return `TEXT' splitted by `SEPARATOR' (default: \"\n\")."
   (save-match-data
     (split-string text separator)))
 
@@ -1119,8 +1091,8 @@ If annotation is a placed on the margin of a window (that is
 nil) the text is broken (regardless of words) to fit on the side
 of the window using `BEGIN-OF-LINE' `END-OF-LINE'.
 
-If annotation is a note that is placed in its own line the text is padded with spaces so that
-a 'box' surround the text without seams, e.g:
+If annotation is a note that is placed in its own line the text is padded
+with spaces so that a 'box' surround the text without seams, e.g:
 
 aaa      aaa
 aa   ->  aa*
@@ -1128,7 +1100,7 @@ a        a**"
   (let ((annotation-text (overlay-get annotation-overlay 'annotation)))
     (cl-labels ((boxify-multiline (raw-annotation-text &optional add-space-at-end)
                   (let* ((lines         (annotate--split-lines raw-annotation-text))
-                         (lines-widths  (mapcar 'string-width lines))
+                         (lines-widths  (mapcar #'string-width lines))
                          (max-width     (cl-reduce (lambda (a b) (if (> a b)
                                                                      a
                                                                    b))
@@ -1156,7 +1128,7 @@ a        a**"
   "Searches the line before point for annotations, and returns a
 'facespec' with the annotation in its 'display' property."
   (save-excursion
-    (let ((newline-position (point)))
+    ;; (let ((newline-position (point)))
       (goto-char (1- (point))) ; we start at the start of the previous line
       ;; find overlays in the preceding line
       (let ((prefix-first       (annotate-make-prefix)) ; white spaces
@@ -1245,13 +1217,14 @@ a        a**"
                     (setq prefix-first prefix-rest))))))
         (when (not annotate-use-echo-area)
           ;; build facespec with the annotation text as display property
-          (if (string= annotation-text "")
-              ;; annotation has been removed: remove display prop
-              (list 'face 'default 'display nil)
-            ;; annotation has been changed/added: change/add display prop
-            (list 'face 'default 'display annotation-text)))))))
+          (list 'face 'default 'display
+                (if (string= annotation-text "")
+                    ;; annotation has been removed: remove display prop
+                    nil
+                  ;; annotation has been changed/added: change/add display prop
+                  annotation-text)))))) ;; )
 
-(defun annotate--remove-annotation-property (begin end)
+(defun annotate--remove-annotation-property (_begin end)
   "Cleans up annotation properties associated within a region
 surrounded by `BEGIN' and `END'."
   (when (and (> (buffer-size) 0)
@@ -1274,7 +1247,7 @@ surrounded by `BEGIN' and `END'."
         (buffer-enable-undo))))))
 
 (defun annotate-annotations-overlay-in-range (from-position to-position)
-  "Returns the annotations overlays that are enclosed in the range
+  "Return the annotations overlays that are enclosed in the range
 defined by `FROM-POSITION' and `TO-POSITION'."
   (let ((annotations ()))
     (cl-loop for  i
@@ -1291,7 +1264,7 @@ defined by `FROM-POSITION' and `TO-POSITION'."
     (reverse annotations)))
 
 (defun annotate-annotations-chain-in-range (from-position to-position)
-  "Returns the annotations (chains) that are enclosed in the range
+  "Return the annotations (chains) that are enclosed in the range
 defined by `FROM-POSITION' and `TO-POSITION'."
   (let ((annotations (annotate-annotations-overlay-in-range from-position to-position))
         (chains      ()))
@@ -1301,7 +1274,7 @@ defined by `FROM-POSITION' and `TO-POSITION'."
     (reverse chains)))
 
 (defun annotate--change-guard ()
-  "Returns a `facespec` with an `insert-behind-hooks` property
+  "Return a `facespec` with an `insert-behind-hooks` property
 that strips dangling `display` properties of text insertions if
 text is inserted. This cleans up after newline insertions between
 an overlay and it's annotation."
@@ -1316,11 +1289,11 @@ If `OMIT-TRAILING-NULL' is non null, empty line at the end of
 text will be discarded."
   (let ((lines (annotate--split-lines text "\n")))
     (when omit-trailing-null
-      (let ((last-not-empty (cl-position-if-not 'annotate-string-empty-p
+      (let ((last-not-empty (cl-position-if-not #'annotate-string-empty-p
                                                 lines
                                                 :from-end t)))
         (setf lines (cl-subseq lines 0 (1+ last-not-empty)))))
-    (apply 'concat (mapcar (lambda (l) (concat prefix l "\n")) lines))))
+    (apply #'concat (mapcar (lambda (l) (concat prefix l "\n")) lines))))
 
 ;;; database related procedures
 
@@ -1408,9 +1381,10 @@ essentially what you get from:
   (list left-limit right-limit))
 
 (defun annotate-annotation-interval (annotation)
-  "Returns a list of two numbers representing the left and right
-limit respectively of the portion of the buffer where this
-annotation is applied.
+  ;; FIXME: Should "interval i the" below be "interval in the"?
+  "Return the limits where ANNOTATION is applied.
+The limit is a list of two numbers (LEFT RIGHT) representing of the portion
+of the buffer where this annotation is applied.
 Note that this function returns the character interval
 yyyyyyyy ggg
   ^^^^^^^  ← Annotation interval i the database (extends for one more than the last character)
@@ -1493,32 +1467,32 @@ essentially what you get from:
 
 The format of the database is:
 
-\(list record-1 record-2 ... record-n)
+\(RECORD-1 RECORD-2 ... RECORD-N)
 
 Each record is:
 
-\(list filename annotations checksum)
+\(FILENAME ANNOTATIONS CHECKSUM)
 
 where:
 
-filename: a string identifying a file on the file-system, or the
+FILENAME: a string identifying a file on the file-system, or the
 string \"dir\" for top-level info file.
 
-checksum: a string used to fingerprint the annotate file above,
+CHECKSUM: a string used to fingerprint the annotate file above,
 used to check if a file has been modified.
 
 annotations:
 
-\(list annotation-1 annotation-2 ... annotation-n) or nil
+\(ANNOTATION-1 ANNOTATION-2 ... ANNOTATION-N) or nil
 
 finally annotation is:
 
-\(list start end annotation-string annotated-text)
+\(START END ANNOTATION-STRING ANNOTATED-TEXT)
 
-start:             the buffer position where annotated text start
-end:               the buffer position where annotated text ends
-annotation-string: the text of annotation
-annotated-text:    the substring of buffer starting from 'start' an ending with 'end' (as above)
+START:             the buffer position where annotated text start
+END:               the buffer position where annotated text ends
+ANNOTATION-STRING: the text of annotation
+ANNOTATED-TEXT:    the substring of buffer from START to END (as above)
 
 example:
 
@@ -1600,7 +1574,7 @@ annotation."
                           file-checksum)))
 
 (defun annotate--deserialize-database-file (file)
-"Returns a sexp from the annotation database contained in `FILE'."
+  "Return a sexp from the annotation database contained in `FILE'."
   (with-temp-buffer
     (let* ((annotations-file file)
            (attributes    (file-attributes annotations-file)))
@@ -1612,7 +1586,7 @@ annotation."
         nil)
        (t
         (insert-file-contents annotations-file)
-        (mapcar 'annotate--expand-record-path (read (current-buffer))))))))
+        (mapcar #'annotate--expand-record-path (read (current-buffer))))))))
 
 (defun annotate-load-annotation-data (&optional ignore-errors)
   "Read and returns saved annotations."
@@ -1898,7 +1872,7 @@ The searched interval can be customized setting the variable:
 'annotate-search-region-lines-delta'."
   (cl-labels ((create-annotation (start end annotation-text)
                (save-excursion
-                 (let ((chain-pos 0)
+                 (let (;; (chain-pos 0)
                        (all-overlays ()))
                    (while (< start end)
                      (goto-char start)
@@ -1981,7 +1955,7 @@ The searched interval can be customized setting the variable:
                                          (face-attribute (cl-first face) :height nil 'default))
                                         (t
                                          (face-attribute 'default :height))))
-                                     (cl-remove-if #'null all-faces)))
+                                     (remq nil all-faces)))
                        (setf force-newline-p
                              (cl-find-if (lambda (a) (/= a default-face-height))
                                          all-faces-height))
@@ -2046,7 +2020,8 @@ This function is not part of the public API."
    (save-excursion
      (with-current-buffer (current-buffer)
        (let* ((chain         (annotate-find-chain annotation))
-              (filename      (annotate-actual-file-name)))
+              ;; (filename      (annotate-actual-file-name))
+              )
          (dolist (single-element chain)
            (goto-char (overlay-end single-element))
            (move-end-of-line nil)
@@ -2185,7 +2160,7 @@ point)."
         (make-string prefix-length ? )))))
 
 (defun annotate-annotation-at (pos)
-  "Returns the annotations (overlay where (annotationp overlay) -> t)
+  "Return the annotations (overlay where (annotationp overlay) -> t)
 at positions `POS' or nil if no annotations exists at pos.
 
 NOTE this assumes that annotations never overlaps so the list of
@@ -2195,7 +2170,7 @@ all annotations can contains only one element maximum."
     (cl-first all)))
 
 (defun annotate-previous-annotation-ends (pos)
-  "Returns the previous annotation that ends before `POS' or nil if no annotation
+  "Return the previous annotation that ends before `POS' or nil if no annotation
 was found.
 NOTE this assumes that annotations never overlaps."
   (cl-labels ((previous-annotation-ends (start)
@@ -2212,12 +2187,12 @@ NOTE this assumes that annotations never overlaps."
         (previous-annotation-ends pos)))))
 
 (defun annotate-previous-annotation (annotation)
- "Returns the annotation before `ANNOTATIONS' or nil if no such
+  "Return the annotation before `ANNOTATIONS' or nil if no such
 annotation exists."
  (annotate-previous-annotation-ends (overlay-start (annotate-chain-first annotation))))
 
 (defun annotate-next-annotation-starts (pos)
-  "Returns the previous annotation that ends before `POS' or nil if no annotation
+  "Return the previous annotation that ends before `POS' or nil if no annotation
 was found.
 NOTE this assumes that annotations never overlaps."
   (cl-labels ((next-annotation-ends (start)
@@ -2234,12 +2209,12 @@ NOTE this assumes that annotations never overlaps."
         (next-annotation-ends pos)))))
 
 (defun annotate-next-annotation (annotation)
- "Returns the annotation after `ANNOTATIONS' or nil if no such
+  "Return the annotation after `ANNOTATIONS' or nil if no such
 annotation exists."
  (annotate-next-annotation-starts (overlay-end (annotate-chain-last annotation))))
 
 (defun annotate-symbol-strictly-at-point ()
- "Returns non nil if a symbol is at char immediately following
+  "Return non nil if a symbol is at char immediately following
 the point. This is needed as `THING-AT-POINT' family of
  functions returns non nil if the thing (a symbol in this case)
  is around the point, according to the documentation."
@@ -2300,30 +2275,31 @@ content `ANNOTATION' and annotated text `ANNOTATED-TEXT'."
   (list beginning ending annotation annotated-text))
 
 (defun annotate-all-annotations ()
-  "Returns a list of all annotations in the current buffer."
+  "Return a list of all annotations in the current buffer."
   (cl-remove-if-not #'annotationp (overlays-in 0 (buffer-size))))
 
 (defun annotate-describe-annotations ()
-  "Returns a list, suitable for database dump, of all annotations in the current buffer."
+  "Return a list of all annotations in the current buffer.
+The format is suitable for database dump."
   (let ((all-annotations (cl-remove-if-not #'annotationp (overlays-in 0 (buffer-size))))
         (chain-visited   ()))
-    (cl-remove-if #'null
-                  (mapcar (lambda (annotation)
-                            (let* ((chain       (annotate-find-chain annotation))
-                                   (chain-first (annotate-chain-first annotation))
-                                   (chain-last  (annotate-chain-last annotation))
-                                   (from        (overlay-start chain-first))
-                                   (to          (overlay-end   chain-last)))
-                              (when (not (cl-find-if (lambda (a)
-                                                       (eq (cl-first chain)
-                                                           (cl-first a)))
-                                                     chain-visited))
-                                (push chain chain-visited)
-                                (list from
-                                      to
-                                      (overlay-get annotation 'annotation)
-                                      (buffer-substring-no-properties from to)))))
-                          all-annotations))))
+    (remq nil
+          (mapcar (lambda (annotation)
+                    (let* ((chain       (annotate-find-chain annotation))
+                           (chain-first (annotate-chain-first annotation))
+                           (chain-last  (annotate-chain-last annotation))
+                           (from        (overlay-start chain-first))
+                           (to          (overlay-end   chain-last)))
+                      (when (not (cl-find-if (lambda (a)
+                                               (eq (cl-first chain)
+                                                   (cl-first a)))
+                                             chain-visited))
+                        (push chain chain-visited)
+                        (list from
+                              to
+                              (overlay-get annotation 'annotation)
+                              (buffer-substring-no-properties from to)))))
+                  all-annotations))))
 
 (defun annotate-info-root-dir-p (filename)
   "Is the name of this file equals to the info root node?"
@@ -2412,7 +2388,7 @@ sophisticated way than plain text."
           (goto-char (button-get button 'go-to))))))))
 
 (defun annotate-update-visited-buffer-maybe (filename)
-"Reload annotation mode in the buffer visiting `FILENAME', if such buffer exists."
+  "Reload annotation mode in the buffer visiting `FILENAME', if such buffer exists."
   (let ((visited-buffer (find-buffer-visiting filename)))
     (when visited-buffer ;; a buffer is visiting the file
       (with-current-buffer visited-buffer
@@ -2425,8 +2401,8 @@ pressed."
   (let* ((filename        (button-get button 'file))
          (beginning       (button-get button 'beginning))
          (ending          (button-get button 'ending))
-         (begin-of-button (button-get button 'begin-of-button))
-         (end-of-button   (button-get button 'end-of-button))
+         ;; (begin-of-button (button-get button 'begin-of-button))
+         ;; (end-of-button   (button-get button 'end-of-button))
          (db              (annotate-load-annotation-data t))
          (filtered        (annotate-db-remove-annotation db filename beginning ending)))
     (annotate-dump-annotation-data filtered) ; save the new database with entry removed
@@ -2603,7 +2579,7 @@ results can be filtered with a simple query language: see
                                  annotate-error-summary-win-filename-invalid)))
               (db-empty-p    (dump)
                              (cl-every (lambda (a)
-                                         (cl-every 'null
+                                         (cl-every #'null
                                                    (annotate-annotations-from-dump a)))
                                        dump))
               (get-query     ()
@@ -2675,20 +2651,20 @@ summary window is shown.")
 
 (defun annotate-summary-query-lexer-start (res)
  "The starting point of the substring of
-`ANNOTATE-SUMMARY-QUERY' for this token."
+`annotate-summary-query' for this token."
   (elt res 2))
 
 (defun annotate-summary-query-lexer-end (res)
   "The ending point of the substring of
-`ANNOTATE-SUMMARY-QUERY' for this token."
+`annotate-summary-query' for this token."
 
   (elt res 3))
 
 (cl-defun annotate-summary-lexer (&optional (look-ahead-p nil))
-  "The lexer for `ANNOTATE-SUMMARY-QUERY'.
+  "The lexer for `annotate-summary-query'.
 
 This function, when called, will produce the next token from
-`ANNOTATE-SUMMARY-QUERY'; a token is a substring with a well
+`annotate-summary-query'; a token is a substring with a well
 defined meaning according to our grammar.
 
 For example this string:
@@ -2717,9 +2693,9 @@ The format is a proper list where:
 
 - third and fourth element (currently unused)
  the substring limits for this token (as returned by
- `MATCH-BEGINNING' and `MATCH-END'
+ `match-beginning' and `match-end'.
 
-Note that spaces are ignored and all the tokens except `RE' must
+Note that spaces are ignored and all the tokens except `re' must
 not be prefixed with a backslash to match. So, for example not ->
 will match the token type 'not but \not will match the token 're;
 this way we can 'protect' a regexp that contains reserved
@@ -2728,14 +2704,14 @@ keyword (aka escaping).
 The special value :no-more-token is returned after the whole
 input is processed.
 
-Calling this function with value of `LOOK-AHEAD-P' nil will `CONSUME' the token from
-`ANNOTATE-SUMMARY-QUERY' (i.e. that string is modified)
+Calling this function with value of LOOK-AHEAD-P nil will `CONSUME' the
+token from `annotate-summary-query' (i.e. that string is modified).
 
 example:
 'a and b' -> 'and b', '(re \"a\" 0 1)
 
-when `LOOK-AHEAD-P' is not nil the token is recognized but not cut away from
-`ANNOTATE-SUMMARY-QUERY'
+when LOOK-AHEAD-P is not nil the token is recognized but not cut away
+from `annotate-summary-query'.
 
 example:
 'a and b' -> 'a and b', '(re \"a\" 0 1)"
@@ -2837,7 +2813,7 @@ Arguments:
               ;; NOTE OPERATOR NOTE
               ;; filter-fn     see the docstring
               ;; matchp        non nil if (funcall filter-fn previous-token) is not nil
-              (operator             (previous-token filter-fn annotation matchp)
+              (operator             (filter-fn annotation matchp)
                (let ((look-ahead        (annotate-summary-lexer t)))
                  (if (annotate-summary-query-parse-end-input-p look-ahead)
                      ;; end of input, recurse one more time
@@ -2933,7 +2909,7 @@ Arguments:
                      (matchp    (funcall filter-fn unescaped annotation)))   ; apply the filter function
                 ;; and finally continue the parsing saving the results
                 ;; of applying the filter-fn function
-                (operator escaped filter-fn annotation matchp)))
+                (operator filter-fn annotation matchp)))
              (t
               ;; here we match the rule:
               ;; NOTE := RE
@@ -2944,7 +2920,7 @@ Arguments:
                      (matchp    (funcall filter-fn regex annotation)))
                 ;; and finally continue the parsing saving the results
                 ;; of applying the filter-fn function
-                (operator regex filter-fn annotation matchp)))))
+                (operator filter-fn annotation matchp)))))
         ;; if we are here the lexer can not find any more tokens in the query
         ;; just return the value of res
         res)))) ; end of `(if (not (annotate-summary-query-parse-end-input-p look-ahead))'
@@ -3124,7 +3100,7 @@ The annotations in each record are sorted by starting point in ascending order."
                                                                     filter-file
                                                                     filter-annotations)))
                                  (setf filtered-annotations
-                                       (cl-remove-if 'null filtered-annotations))
+                                       (remq nil filtered-annotations))
                                  (when filtered-annotations
                                    (let ((filename (annotate-filename-from-dump
                                                     single-annotation))
@@ -3132,7 +3108,7 @@ The annotations in each record are sorted by starting point in ascending order."
                                                     single-annotation)))
                                      (setf filtered-annotations
                                            (sort filtered-annotations
-                                                 'annotate-db-annotations-starts-before-p))
+                                                 #'annotate-db-annotations-starts-before-p))
                                      (when remove-annotations-cutoff-point
                                        (setf filtered-annotations
                                              (cl-remove-if (lambda (a)
@@ -3142,7 +3118,7 @@ The annotations in each record are sorted by starting point in ascending order."
                                      (annotate-make-annotation-dump-entry filename
                                                                           filtered-annotations
                                                                           checksum))))))
-         (filtered           (cl-remove-if 'null (mapcar filter annotations-dump))))
+         (filtered           (remq nil (mapcar filter annotations-dump))))
     filtered))
 
 ;;;; end of filtering: parser, lexer, etc.
@@ -3162,12 +3138,12 @@ position."
 ;;; switching database
 
 (defun annotate-buffers-annotate-mode ()
- "Returns a list of all the buffers that have
+  "Return a list of all the buffers that have
 annotate minor mode active."
   (let ((all-buffers (buffer-list)))
     (cl-labels ((annotate-mode-p (buffer)
                   (with-current-buffer buffer
-                    (and (boundp 'annotate-mode)
+                    (and (boundp 'annotate-mode) ;FIXME: Redundant test?
                          annotate-mode))))
       (cl-remove-if-not #'annotate-mode-p all-buffers))))
 
@@ -3228,7 +3204,7 @@ The new interval is expanded so that includes `A' and `B'."
                              new-right-limit)))
 
 (defun annotate--db-annotations-overlaps-p (annotation-a annotation-b)
-"Returns non nil if `ANNOTATION-A' and `ANNOTATION-B' overlaps."
+  "Return non nil if `ANNOTATION-A' and `ANNOTATION-B' overlaps."
   (let ((interval-a (annotate-annotation-interval annotation-a))
         (interval-b (annotate-annotation-interval annotation-b)))
     (not (or (< (annotate--interval-right-limit interval-b)
@@ -3237,7 +3213,8 @@ The new interval is expanded so that includes `A' and `B'."
                 (annotate--interval-right-limit interval-a))))))
 
 (defun annotate--db-merge-annotations (host guest)
-"Merge annotation `GUEST' into annotation `HOST' using `ANNOTATE--MERGE-INTERVAL'."
+  "Merge annotation GUEST into annotation HOST.
+Uses `annotate--merge-interval'."
   (when (annotate--db-annotations-overlaps-p host guest)
     (let* ((interval-host       (annotate-annotation-interval host))
            (interval-guest      (annotate-annotation-interval guest))
@@ -3257,7 +3234,7 @@ using `ANNOTATE--DB-MERGE-ANNOTATIONS'."
   (if (= (length annotations) 1)
       (push (cl-first annotations) accum)
     (let* ((probe            (cl-first annotations))
-           (rest-annotations (rest annotations))
+           (rest-annotations (cl-rest annotations))
            (position-overlap (cl-position-if (lambda (a)
                                                (annotate--db-annotations-overlaps-p probe a))
                                              rest-annotations)))
@@ -3320,7 +3297,10 @@ their personal database."
   (let* ((confirm-message    (concat "Importing databases from untrusted source may cause severe "
                                      "security issues, continue? [y/N] "))
          (import-confirmed-p (or (not annotate-database-confirm-import)
-                                 (string= (read-from-minibuffer (format confirm-message
+                                 ;; FIXME: There's no `%s' in `confirm-message'
+                                 ;; to make use of the `annotate-file' arg?
+                                 ;; FIXME: Use `y-or-n-p' or `yes-or-no-p'!
+                                 (string= (read-string (format confirm-message
                                                                         annotate-file))
                                           "y"))))
     (when import-confirmed-p

--- a/annotate.el
+++ b/annotate.el
@@ -131,9 +131,11 @@ that Emacs passes to the diff program."
   :type 'string)
 
 (defcustom annotate-blacklist-major-mode '()
-  ;; FIXME: When/why would this be needed?
-  "Prevent loading of annotate-mode When the visited file's
-major mode is a member of this list (space separated entries)."
+ "Prevent loading of annotate-mode When the visited file's major
+mode is a member of this list (space separated entries). This
+could be useful if some mode does not work well with annotate as
+this ensure that it will be never loaded, see
+`annotate-initialize-maybe'."
   :type  '(repeat symbol))
 
 (defcustom annotate-summary-ask-query t
@@ -435,7 +437,9 @@ modified (for example a newline is inserted)."
   "Load annotations and set up save and display hooks."
   (annotate-load-annotations)
   (add-hook 'after-save-hook                  #'annotate-save-annotations t t)
-  (add-hook 'window-configuration-change-hook #'font-lock-flush  t t) ;FIXME: Why?
+  ;; This hook  is needed to  reorganize the layout of  the annotation
+  ;; text when a window vertically resized
+  (add-hook 'window-configuration-change-hook #'font-lock-flush  t t)
   (add-hook 'before-change-functions          #'annotate-before-change-fn t t)
   (add-hook 'Info-selection-hook              #'annotate-info-select-fn   t t)
   (if annotate-use-echo-area

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.5.0
+;; Version: 1.5.1
 
 ;; This file is NOT part of GNU Emacs.
 

--- a/annotate.el
+++ b/annotate.el
@@ -76,7 +76,10 @@
 See https://github.com/bastibe/annotate.el/ for documentation."
   :lighter " Ann"
   :group 'annotate
-  ;; FIXME: Why `:after-hook'?
+  ;; we use  `:after-hook` to prevent running  initialization code for
+  ;; this mode if  the buffer already has annotate-mode  active and to
+  ;; prevent  loading   the  annotate   in  blacklisted   modes  (see:
+  ;; `annotate-blacklist-major-mode').
   :after-hook (annotate-initialize-maybe))
 
 (defcustom annotate-file (locate-user-emacs-file "annotations" ".annotations")
@@ -314,7 +317,7 @@ annotation as defined in the database."
 
 (defun annotate-initialize-maybe ()
   "Initialize annotate mode only if buffer's major mode is not in the blacklist.
-See 'annotate-blacklist-major-mode'."
+See: `annotate-blacklist-major-mode'."
   (let ((annotate-allowed-p (with-current-buffer (current-buffer)
                               (not (apply #'derived-mode-p annotate-blacklist-major-mode)))))
     (cond

--- a/annotate.el
+++ b/annotate.el
@@ -558,12 +558,13 @@ specified by `FROM' and `TO'."
                      (annotate-empty-annotation-text-error
                       (user-error "Annotation text is empty"))))))
               (cut-right (region-beg region-stop &optional delete-enclosed)
-                ;; This function will trim on the right one or more
-                ;; existing chains of overlays that compose an
-                ;; annotation (i.e. the overlays applied on the
-                ;; annotated text). After this function is called the
-                ;; text staring from `region-beg' end ending on
-                ;; `region-stop' will be cleared of all annotations.
+                ;; This function  will trim on  the right one  or more
+                ;; existing  chains   of  overlays  that   compose  an
+                ;; annotation  (i.e.  the   overlays  applied  on  the
+                ;; annotated text). After this  function is called the
+                ;; text  staring  from   `region-beg'  and  ending  on
+                ;; `region-stop' will be cleared of all annotations if
+                ;; `delete-enclosed' is non null.
                 (let* ((last-of-chain-to-cut  (annotate-chain-last-at region-beg))
                        (first-of-chain-to-cut (annotate-chain-first-at region-beg))
                        (chain-start           (overlay-start first-of-chain-to-cut))
@@ -579,12 +580,14 @@ specified by `FROM' and `TO'."
                   (when delete-enclosed
                     (annotate-delete-chains-in-region chain-end region-stop))))
               (cut-left (region-stop delete-enclosed)
-                ;; This function will trim on the left one or more
-                ;; existing chains of overlays that compose an
-                ;; annotation (i.e. the overlays applied on the
-                ;; annotated text). After this function is called the
-                ;; text staring from `region-beg' end ending on
-                ;; `region-stop' will be cleared of all annotations.
+                ;; This function  will trim  on the  left one  or more
+                ;; existing  chains   of  overlays  that   compose  an
+                ;; annotation  (i.e.   the  overlays  applied  on  the
+                ;; annotated text). After this  function is called the
+                ;; text starting from the last  char of the last chain
+                ;; element   of   the   annotation   and   ending   on
+                ;; `region-stop' will be cleared of all annotations if
+                ;; `delete-enclosed' is non null.
                 (let* ((last-of-chain-to-cut  (annotate-chain-last-at region-stop))
                        (first-of-chain-to-cut (annotate-chain-first-at region-stop))
                        (chain-start           (overlay-start first-of-chain-to-cut))

--- a/annotate.el
+++ b/annotate.el
@@ -1210,12 +1210,11 @@ a        a**"
                     (setq prefix-first prefix-rest))))))
         (when (not annotate-use-echo-area)
           ;; build facespec with the annotation text as display property
-          (list 'face 'default 'display
-                (if (string= annotation-text "")
-                    ;; annotation has been removed: remove display prop
-                    nil
-                  ;; annotation has been changed/added: change/add display prop
-                  annotation-text)))))) ;; )
+          (if (string= annotation-text "")
+              ;; annotation has been removed: remove display prop
+              (list 'face 'default 'display nil)
+            ;; annotation has been changed/added: change/add display prop
+            (list 'face 'default 'display annotation-text))))))
 
 (defun annotate--remove-annotation-property (_begin end)
   "Cleans up annotation properties associated within a region

--- a/annotate.el
+++ b/annotate.el
@@ -490,9 +490,8 @@ that belong to some annotated text?"
   (let ((annotation (annotate-annotation-at pos)))
     (if annotation
         t
-      ;; there is a chance that a point do not belong text rendered as
-      ;; annotated but belong to a chain anyway
-      ;; example:
+      ;; there is  a chance  that a  point do not  belong to  the text
+      ;; rendered as annotated but belong to a chain anyway example:
       ;;
       ;; legend:
       ;; a = annotated text


### PR DESCRIPTION
Hi!

This PR collect the suggestions from a kind Emacs maintainer.

Some of them are really useful (like the docstring and using some library function instead of custom code), some are a bit scary like using lexical scoping by default (i think we used dynamic scoped variables in some portion of the code, but if not i am all to switch to lexical scoping), some other are style changes that may o may not like. I am going to study all the changes because i think i need to know what the modifications do before merging.

So, in conclusion this is a code review from Emacs team! :+1: 

Bye!
C.
