### PR TITLE
Fixed deletion of annotations;

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,32 @@
+2022-03-09 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - increased version number.
+        - updated NEWS.org.
+
+2022-03-03 cage
+
+        * annotate.el:
+
+        - added an email address to contact the developers;
+        - removed ':after-hook' in define-minor-mode, and moved
+        'annotation-initialize-maybe' in the macro's body;
+        - changed 'window-configuration-change-hook' with
+        'window-size-change-functions'.
+        - updated docstrings.
+
+2022-02-26 cage
+
+        * annotate.el:
+
+        - fixed deletion of annotations;
+        The   function  'annotate-delete-annotation'   does   not  set   the
+        modification bit after deleting, so the annotation was not deleted at
+        all if the buffer was saved just after calling this command.
+        Also the coloring of the rest of the annotation was not updated.
+
 2022-02-16 cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,5 +1,13 @@
 - 2022-01-26 v1.5.1 cage ::
 
+  This version fixed a bug that prevented an annotation to be actually
+  deleted when the only action on the  buffer was a single call of the
+  command  `annotate-delete-annotation'.  Also,  again  thanks to  the
+  help of  an Emacs maintainer,  the code was simplified  and cleaned,
+  and a few of docstring was improved too.
+
+- 2022-01-26 v1.5.1 cage ::
+
   This version refactored  a lot of code thanks to  the suggestions of
   Emacs  maintainer. Several  unused variables  were removed  and some
   portion of the code was simplified.

--- a/annotate.el
+++ b/annotate.el
@@ -100,16 +100,18 @@ See https://github.com/bastibe/annotate.el/ for documentation."
 
 (defface annotate-prefix
   '((t (:inherit default)))
- "Face for character used to pad annotation (fill space between
-text lines and annotation text).")
+ "Face for character used to pad annotation.
+This is the fill space between text lines and annotation text.")
 
 (defcustom annotate-annotation-column 85
   "Where annotations appear."
   :type 'number)
 
 (defcustom annotate-diff-export-options ""
- "Other options for diffing between a buffer with and without integrated annotations.
-Note that there is an implicit -u at the end of default options
+ "Options passed to `diff' in `annotate-export-annotations'.
+This is used when diffing between a buffer with and without
+integrated annotations.
+Note that there is an implicit `-u' at the end of default options
 that Emacs passes to the diff program."
   :type 'string)
 
@@ -130,9 +132,9 @@ that Emacs passes to the diff program."
   :type 'string)
 
 (defcustom annotate-blacklist-major-mode '()
- "Prevent loading of annotate-mode When the visited file's major
-mode is a member of this list (space separated entries). This
-could be useful if some mode does not work well with
+  "Major modes in which to prevent auto-activation of `annotate-mode'.
+This is consulted when visiting a file.
+It can be useful when some mode does not work well with
 annotate (like source blocks in org-mode) as this ensure that it
 will be never loaded, see `annotate-initialize-maybe'."
   :type  '(repeat symbol))
@@ -313,7 +315,7 @@ annotation as defined in the database."
 
 (defun annotate-initialize-maybe ()
   "Initialize annotate mode only if buffer's major mode is not in the blacklist.
-See: `annotate-blacklist-major-mode'."
+See `annotate-blacklist-major-mode'."
   (let ((annotate-allowed-p (with-current-buffer (current-buffer)
                               (not (apply #'derived-mode-p annotate-blacklist-major-mode)))))
     (cond

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold co-maintainer: cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.5.1
+;; Version: 1.5.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.5.0"
+  :version "1.5.2"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -4,7 +4,7 @@
 ;; Universita' degli Studi di Palermo (2019)
 
 ;; Author: Bastian Bechtold
-;; Maintainer: Bastian Bechtold
+;; Maintainer: Bastian Bechtold co-maintainer: cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
 ;; Version: 1.5.1
@@ -76,11 +76,7 @@
 See https://github.com/bastibe/annotate.el/ for documentation."
   :lighter " Ann"
   :group 'annotate
-  ;; we use  `:after-hook` to prevent running  initialization code for
-  ;; this mode if  the buffer already has annotate-mode  active and to
-  ;; prevent  loading   the  annotate   in  blacklisted   modes  (see:
-  ;; `annotate-blacklist-major-mode').
-  :after-hook (annotate-initialize-maybe))
+  (annotate-initialize-maybe))
 
 (defcustom annotate-file (locate-user-emacs-file "annotations" ".annotations")
   "File where annotations are stored."
@@ -136,9 +132,9 @@ that Emacs passes to the diff program."
 (defcustom annotate-blacklist-major-mode '()
  "Prevent loading of annotate-mode When the visited file's major
 mode is a member of this list (space separated entries). This
-could be useful if some mode does not work well with annotate as
-this ensure that it will be never loaded, see
-`annotate-initialize-maybe'."
+could be useful if some mode does not work well with
+annotate (like source blocks in org-mode) as this ensure that it
+will be never loaded, see `annotate-initialize-maybe'."
   :type  '(repeat symbol))
 
 (defcustom annotate-summary-ask-query t
@@ -440,7 +436,7 @@ modified (for example a newline is inserted)."
   (add-hook 'after-save-hook                  #'annotate-save-annotations t t)
   ;; This hook  is needed to  reorganize the layout of  the annotation
   ;; text when a window vertically resized
-  (add-hook 'window-configuration-change-hook #'font-lock-flush  t t)
+  (add-hook 'window-size-change-functions     #'font-lock-flush t t)
   (add-hook 'before-change-functions          #'annotate-before-change-fn t t)
   (add-hook 'Info-selection-hook              #'annotate-info-select-fn   t t)
   (if annotate-use-echo-area
@@ -456,7 +452,7 @@ modified (for example a newline is inserted)."
   "Clear annotations and remove save and display hooks."
   (annotate-clear-annotations)
   (remove-hook 'after-save-hook                  #'annotate-save-annotations t)
-  (remove-hook 'window-configuration-change-hook #'font-lock-flush  t)
+  (remove-hook 'window-size-change-functions     #'font-lock-flush t)
   (remove-hook 'before-change-functions          #'annotate-before-change-fn t)
   (remove-hook 'Info-selection-hook              #'annotate-info-select-fn   t)
   (if annotate-use-echo-area

--- a/annotate.el
+++ b/annotate.el
@@ -2108,7 +2108,9 @@ point)."
   (when-let ((annotation (annotate-annotation-at point)))
     (let* ((delete-confirmed-p (annotate--confirm-annotation-delete)))
       (when delete-confirmed-p
-        (annotate--delete-annotation-chain annotation)))))
+        (annotate--delete-annotation-chain annotation)
+        (font-lock-flush)
+        (set-buffer-modified-p t)))))
 
 (defun annotate-change-annotation (pos)
   "Change annotation at point. If empty, delete annotation."


### PR DESCRIPTION
Hi @bastibe   

This a quick fix for properly deletion of annotation using `C-d`. Also an Emacs maintainer asked me to add an email address on one of the top comments of the file as this is used to notify problem building the package on NonGNU ELPA. I would add my email but i thought asking you before was the right thing to do, i am OK if you want to add your instead too,  so choose freely! :)

Bye!
C.