### PR TITLE
Fix run hook when emacs killed

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,15 @@
+2022-08-02 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - modified the function called when kill-emacs-hook runs
+          The  new function  ensures  all the  buffers,  where annotate-mode  is
+          active, save the annotationos in  the database; also this function is
+          registered in the global hooks list.
+        - increased version number.
+        - updated NEWS.org.
+
 2022-06-23 cage
 
         * annotate.el:

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+- 2022-08-02 v1.7.1 cage ::
+
+  This version fix  a bug that prevented saving  some annotations when
+  Emacs was closed.
+
 - 2022-05-26 v1.7.0 cage ::
 
   This  version no  more sets  the buffer  as modified  when the  only

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.7.0
+;; Version: 1.7.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.7.0"
+  :version "1.7.1"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -1433,7 +1433,7 @@ essentially what you get from:
 
 (defun annotate-save-all-annotated-buffers ()
   "Save the annotations for all buffer where annotate-mode is active"
-  (let ((all-annotated-buffers (annotate-buffers-annotate-mode )))
+  (let ((all-annotated-buffers (annotate-buffers-annotate-mode)))
     (cl-loop for annotated-buffer in all-annotated-buffers do
              (with-current-buffer annotated-buffer
                (annotate-save-annotations)))))

--- a/annotate.el
+++ b/annotate.el
@@ -469,7 +469,7 @@ local version (i.e. a different database for each annotated file"
   (annotate--maybe-database-set-buffer-local)
   (annotate-load-annotations)
   (add-hook 'kill-buffer-hook                 #'annotate-save-annotations t t)
-  (add-hook 'kill-emacs-hook                  #'annotate-save-annotations t t)
+  (add-hook 'kill-emacs-hook                  #'annotate-save-all-annotated-buffers t nil)
   ;; This hook  is needed to  reorganize the layout of  the annotation
   ;; text when a window vertically resized
   (add-hook 'window-size-change-functions     #'on-window-size-change t t)
@@ -488,7 +488,7 @@ local version (i.e. a different database for each annotated file"
   "Clear annotations and remove save and display hooks."
   (annotate-clear-annotations)
   (remove-hook 'kill-buffer-hook                 #'annotate-save-annotations t)
-  (remove-hook 'kill-emacs-hook                  #'annotate-save-annotations t)
+  (remove-hook 'kill-emacs-hook                  #'annotate-save-all-annotated-buffers nil)
   (remove-hook 'window-size-change-functions     #'on-window-size-change t)
   (remove-hook 'before-change-functions          #'annotate-before-change-fn t)
   (remove-hook 'Info-selection-hook              #'annotate-info-select-fn   t)
@@ -1430,6 +1430,13 @@ essentially what you get from:
 \(annotate-annotations-from-dump (nth index (annotate-load-annotations))))."
   (and (> (length annotation) 3)
        (nth 3 annotation)))
+
+(defun annotate-save-all-annotated-buffers ()
+  "Save the annotations for all buffer where annotate-mode is active"
+  (let ((all-annotated-buffers (annotate-buffers-annotate-mode )))
+    (cl-loop for annotated-buffer in all-annotated-buffers do
+             (with-current-buffer annotated-buffer
+               (annotate-save-annotations)))))
 
 (defun annotate-save-annotations ()
   "Save all annotations to disk."


### PR DESCRIPTION
Hi!

There is a bug in the previous version of the code that  prevented the database to be updated with the annotations contained in non visible buffers, when Emacs is closed. Those annotations was, in effect, lost.

Although i am not sure the code is optimized this patch remove the bug described above.

Sorry for the inconvenience.
C.