### PR TITLE
Fix closing indirect buffer

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,33 @@
+2022-08-31 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - updated, and added if missing, docstrings.
+        - updated NEWS.org.
+        - removed a duplicated label using a constant.
+
+2022-08-25 cage
+
+        * annotate.el:
+
+        - shown a warning when killing an indirect buffer;
+        - reverted code in initialization procedure.
+
+2022-08-23 cage
+
+        * annotate.el:
+
+        - create a proper buffer from an indirect one that has been annotated.
+
+2022-08-22 cage
+
+        * annotate.el:
+
+        - signalled  a warning,  not an  error, when  annotated buffer  is not
+        visiting a file supported by annotate mode.
+        - returned nil as the actual filename of an indirect buffer.
+
 2022-08-10 cage
 
         * NEWS.org,

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,13 @@
+2022-08-10 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - fixed an error that was signalled when the annotated buffer was an
+        indirect one.
+        - increased version number;
+        - updated NEWS.org.
+
 2022-08-02 cage
 
         * NEWS.org,

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+- 2022-08-02 v1.7.2 cage ::
+
+  This version removed an error signalled when closing an annotated indirect buffer.
+  Thanks JuanManuelM!
+
 - 2022-08-02 v1.7.1 cage ::
 
   This version fix  a bug that prevented saving  some annotations when

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,6 +1,10 @@
 - 2022-08-02 v1.7.2 cage ::
 
-  This version removed an error signalled when closing an annotated indirect buffer.
+  This version  removed an error  signalled when closing  an annotated
+  indirect  buffer.  Instead,  when  an annotated  indirect buffer  is
+  killed annotate-mode will clone it into a new regular buffer so that
+  the user can decide to save it in a file or discard it completely.
+
   Thanks JuanManuelM!
 
 - 2022-08-02 v1.7.1 cage ::

--- a/annotate.el
+++ b/annotate.el
@@ -313,6 +313,9 @@ annotation as defined in the database."
 (defconst annotate-message-annotation-loaded "Annotations loaded."
   "The message shown when annotations has been loaded")
 
+(defconst annotate-message-annotations-not-found "No annotations found."
+  "The message shown when no annotations has been loaded from the database.")
+
 ;;;; custom errors
 
 (define-error 'annotate-error "Annotation error")
@@ -1560,7 +1563,7 @@ essentially what you get from:
                                     annotations))
     (when (and (null annotations)
                annotate-use-messages)
-      (message "No annotations found."))
+      (message annotate-message-annotations-not-found))
     (when (not (null annotations))
       (save-excursion
         (dolist (annotation annotations)
@@ -1630,7 +1633,7 @@ example:
         (cond
          ((and (null annotations)
                annotate-use-messages)
-          (message "No annotations found."))
+          (message annotate-message-annotations-not-found))
         (annotations
          (save-excursion
            (dolist (annotation annotations)

--- a/annotate.el
+++ b/annotate.el
@@ -147,10 +147,10 @@ that Emacs passes to the diff program."
   :type 'string)
 
 (defcustom annotate-blacklist-major-mode '()
-  "Major modes in which to prevent auto-activation of `annotate-mode'.
+  "Major modes in which to prevent auto-activation of command `annotate-mode'.
 This is consulted when visiting a file.
 It can be useful when some mode does not work well with
-annotate (like source blocks in org-mode) as this ensure that it
+annotate (like source blocks in `org-mode') as this ensure that it
 will be never loaded, see `annotate-initialize-maybe'."
   :type  '(repeat symbol))
 
@@ -247,7 +247,7 @@ an annotations could not be restored.")
 (defconst annotate-warn-buffer-has-no-valid-file
   "Annotations can not be saved: unable to find a file for buffer %S"
   "The message to warn the user that a buffer it is not visiting
- a valid file to be annotated.")
+a valid file to be annotated.")
 
 (defconst annotate-popup-warn-killing-an-indirect-buffer
   (concat "You killed an indirect buffer that contains annotation.\n"
@@ -257,7 +257,7 @@ an annotations could not be restored.")
           "If you want you can save that buffer in a file and "
           "the annotations will be saved as well.")
   "The message to warn the user that an annotated indirect buffer
- has been killed.")
+has been killed.")
 
 (defconst annotate-error-summary-win-filename-invalid
   "Error: File not found or in an unsupported format"
@@ -296,7 +296,7 @@ annotation as defined in the database."
   "The name of the buffer for summary window.")
 
 (defconst annotate-dump-from-indirect-bugger-suffix "-was-annotated-indirect-buffer"
-  "Append this suffix to a buffer generated from an annotated indirect buffer")
+  "Append this suffix to a buffer generated from an annotated indirect buffer.")
 
 (defconst annotate-annotation-prompt "Annotation: "
   "The prompt when asking user for annotation modification.")
@@ -380,7 +380,7 @@ position (so that it is unchanged after this function is called)."
     (point)))
 
 (defun annotate-annotated-text-empty-p (annotation)
-  "Does this annotation contains annotated text?"
+  "Does this `ANNOTATION' contains annotated text?"
   (= (overlay-start annotation)
      (overlay-end   annotation)))
 
@@ -471,7 +471,7 @@ note that the argument `FRAME' is ignored"
   (font-lock-flush))
 
 (defun annotate--filepath->local-database-name (filepath)
- "Generates the file path of the local database form `FILEPATH'"
+ "Generates the file path of the local database form `FILEPATH'."
   (concat (file-name-nondirectory filepath)
           "."
           annotate-buffer-local-database-extension))
@@ -534,7 +534,7 @@ local version (i.e. a different database for each annotated file"
   (annotate-overlay-filled-p overlay))
 
 (cl-defmacro annotate-ensure-annotation ((overlay) &body body)
-  "Runs body only if `OVERLAY' is an annotation (i.e. passes annotationp)."
+  "Runs `BODY' only if `OVERLAY' is an annotation (i.e. passes annotationp)."
   `(and (annotationp ,overlay)
         (progn ,@body)))
 
@@ -1347,9 +1347,11 @@ buffer is not on info-mode"
   (annotate-guess-filename-for-dump Info-current-file nil))
 
 (cl-defun annotate-indirect-buffer-p (&optional (buffer (current-buffer)))
+  "Returns non nil if `BUFFER' (default the current buffer) is an indirect buffer."
   (buffer-base-buffer buffer))
 
 (defun annotate-indirect-buffer-current-p ()
+"Returns non nil if the current buffer is an indirect buffer."
   (annotate-indirect-buffer-p))
 
 (defun annotate-actual-file-name ()
@@ -1465,13 +1467,16 @@ essentially what you get from:
        (nth 3 annotation)))
 
 (defun annotate-save-all-annotated-buffers ()
-  "Save the annotations for all buffer where annotate-mode is active"
+  "Save the annotations for all buffer where `annotate-mode' is active."
   (let ((all-annotated-buffers (annotate-buffers-annotate-mode)))
     (cl-loop for annotated-buffer in all-annotated-buffers do
              (with-current-buffer annotated-buffer
                (annotate-save-annotations)))))
 
 (cl-defun annotate--dump-indirect-buffer (annotations &optional (indirect-buffer (current-buffer)))
+"Clone an annotated indirect buffer into a new buffer.
+`ANNOTATIONS' containd the annotations and `INDIRECT-BUFFER'
+\(default the current buffer) is the buffer to be cloned."
   (when annotations
     (let* ((new-buffer-name  (generate-new-buffer-name (concat (buffer-name indirect-buffer)
                                                                annotate-dump-from-indirect-bugger-suffix)))
@@ -1939,25 +1944,25 @@ in a chain of annotations as last."
           (reverse results))))))
 
 (defun annotate-annotations-chain-at (pos)
-  "Find all annotation that are parts of the chain that overlaps at `point'."
+  "Find all annotation that are parts of the chain that overlaps at `POS'."
   (annotate-find-chain (annotate-annotation-at pos)))
 
 (defun annotate-create-annotation (start end annotation-text annotated-text)
-  "Create a new annotation for selected region.
+  "Create a new annotation for selected region (from `START' to  `END'.
 
-Here the argument 'annotation-text' is the string that appears
+Here the argument 'ANNOTATION-TEXT' is the string that appears
 on the margin of the window and 'annotated-text' is the string
 that is underlined.
 
 If this function is called from procedure
-'annotate-load-annotations' the argument 'annotated-text'
+'annotate-load-annotations' the argument `ANNOTATED-TEXT'
 should be not null. In this case we know that an annotation
 existed in a text interval defined in the database
 metadata (the database located in the file specified by the
 variable 'annotate-file') and should just be
 restored. Sometimes the annotated text (see above) can not be
 found in said interval because the annotated file's content
-changed and annotate-mode could not track the
+changed and `annotate-mode' could not track the
 changes (e.g. save the file when annotate-mode was not
 active/loaded) in this case the matching
 text ('annotated-text') is searched in a region surrounding the
@@ -2220,7 +2225,7 @@ point)."
         (font-lock-flush)))))
 
 (defun annotate-change-annotation (pos)
-  "Change annotation at point. If empty, delete annotation."
+  "Change annotation at `POS'.  If empty, delete annotation."
   (let* ((highlight       (annotate-annotation-at pos))
          (annotation-text (read-from-minibuffer annotate-annotation-prompt
                                                 (overlay-get highlight 'annotation))))
@@ -2396,12 +2401,12 @@ The format is suitable for database dump."
                   all-annotations))))
 
 (defun annotate-info-root-dir-p (filename)
-  "Is the name of this file equals to the info root node?"
+  "Is the name of this file (`FILENAME') equals to the info root node?"
   (string= filename
            annotate-info-root-name))
 
 (defun annotate-guess-file-format (filename)
-  "Try to guess the file format.
+  "Try to guess the file format from `FILENAME'.
 Non nil if the file format is supported from 'annotate' in a more
 sophisticated way than plain text."
   (cl-labels ((file-contents ()
@@ -2788,7 +2793,7 @@ The format is a proper list where:
  `match-beginning' and `match-end'.
 
 Note that spaces are ignored and all the tokens except `re' must
-not be prefixed with a backslash to match. So, for example not ->
+not be prefixed with a backslash to match.  So, for example not ->
 will match the token type 'not but \not will match the token 're;
 this way we can 'protect' a regexp that contains reserved
 keyword (aka escaping).
@@ -3368,7 +3373,7 @@ using `ANNOTATE--DB-MERGE-ANNOTATIONS'."
                                         (push first-record accum)))))))
 
 (defun annotate-import-annotations ()
-"Prompt user for an annotation database file and merge it int
+"Prompt user for an annotation database file and merge it into
 their personal database."
   (interactive)
   (cl-flet ((deserialize-db (file)

--- a/annotate.el
+++ b/annotate.el
@@ -1329,12 +1329,19 @@ text will be discarded."
 buffer is not on info-mode"
   (annotate-guess-filename-for-dump Info-current-file nil))
 
+(cl-defun annotate-indirect-buffer-p (&optional (buffer (current-buffer)))
+  (buffer-base-buffer buffer))
+
 (defun annotate-actual-file-name ()
   "Get the actual file name of the current buffer."
-  (substring-no-properties (or (annotate-info-actual-filename)
-                               (buffer-file-name)
-                               (buffer-file-name (buffer-base-buffer))
-                               "")))
+  (cond
+   ((annotate-indirect-buffer-p)
+    nil)
+   (t
+    (substring-no-properties (or (annotate-info-actual-filename)
+                                 (buffer-file-name)
+                                 (buffer-file-name (buffer-base-buffer))
+                                 "")))))
 
 (cl-defun annotate-guess-filename-for-dump (filename
                                             &optional (return-filename-if-not-found-p t))

--- a/annotate.el
+++ b/annotate.el
@@ -310,6 +310,9 @@ annotation as defined in the database."
 (defconst annotate-confirm-deleting-annotation-prompt  "Delete this annotation? "
   "Prompt to be shown when asking for annotation deletion confirm.")
 
+(defconst annotate-message-annotation-loaded "Annotations loaded."
+  "The message shown when annotations has been loaded")
+
 ;;;; custom errors
 
 (define-error 'annotate-error "Annotation error")
@@ -1567,7 +1570,7 @@ essentially what you get from:
             (annotate-create-annotation start end annotation-string nil)))))
     (font-lock-flush)
     (when annotate-use-messages
-      (message "Annotations loaded."))))
+      (message annotate-message-annotation-loaded))))
 
 (defun annotate-load-annotations ()
   "Load all annotations from disk and redraw the buffer to render the annotations.
@@ -1641,7 +1644,7 @@ example:
                                            annotated-text))))))
         (font-lock-flush)
         (when annotate-use-messages
-          (message "Annotations loaded."))))))
+          (message annotate-message-annotation-loaded))))))
 
 (defun annotate-db-clean-records (records-db)
   "Remove records from arg `RECORDS-DB' that have empty annotation, example:

--- a/annotate.el
+++ b/annotate.el
@@ -240,6 +240,11 @@ annotations positions could be outdated.")
   "The message to warn the user that file has been modified and
 an annotations could not be restored.")
 
+(defconst annotate-warn-buffer-has-no-valid-file
+  "Annotations can not be saved: unable to find a file for buffer %S"
+  "The message to warn the user that a buffer it is not visiting
+ a valid file to be annotated.")
+
 (defconst annotate-error-summary-win-filename-invalid
   "Error: File not found or in an unsupported format"
  "The message to warn the user that file can not be show in
@@ -1468,8 +1473,10 @@ essentially what you get from:
                                                        all-annotations))
           (when annotate-use-messages
             (message "Annotations saved.")))
-      (user-error "Annotations can not be saved: unable to find a file for buffer %S"
-                  (current-buffer)))))
+      (lwarn '(annotate-mode)
+             :warning
+             annotate-warn-buffer-has-no-valid-file
+             (current-buffer)))))
 
 (defun annotate-load-annotation-old-format ()
   "Load all annotations from disk in old format."

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.7.1
+;; Version: 1.7.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.7.1"
+  :version "1.7.2"
   :group 'text)
 
 (defvar annotate-mode-map


### PR DESCRIPTION
When an annotated indirect buffer was closed the procedure was processing a database entry where the filename was `nil`. This type is invalid and an error was signaled, preventing the buffer to be closed.

This patch supposed to fixes #134 

Bye!
C.