### PR TITLE
Fix integrate inplace

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,27 @@
+022-10-20 cage
+
+        * annotate.el:
+
+        - fixed  integration of  annotation when  the buffer  was modified  to
+        accommodate the annotations text;
+        - fixed typo.
+
+2022-09-30 cage2
+
+
+        Merge pull request #137 from cage2/print-message-annotate-under-point
+
+2022-09-28 cage
+
+        * README.org,
+        * annotate.el:
+
+        - made delay before printing annotations on minibuffer customizable;
+        - updated README.org.
+
 2022-09-21 cage
 
+        * Changelog,
         * NEWS.org,
         * README.org,
         * annotate.el:
@@ -9,6 +31,7 @@
         - updated version number;
         - updated NEWS.org;
         - updated README.org.
+        - updated Changelog.
 
 2022-09-16 cage
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,8 @@
+- 2022-10-20 v1.8.1 cage ::
+
+  This version  fix the command  ~annotate-integrate-annotations~ that
+  was corrupting the buffer containing the annotations, when used.
+
 - 2022-09-21 v1.8.0 cage ::
 
   This version  allows printing  of the  annotation in  the minibuffer

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.8.0
+;; Version: 1.8.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.8.0"
+  :version "1.8.1"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -138,7 +138,7 @@ that Emacs passes to the diff program."
   "Marker that is written before every integrated annotation."
   :type 'string)
 
-(defcustom annotate-integrate-higlight ?~
+(defcustom annotate-integrate-highlight ?~
   "Character used to underline an annotated text."
   :type 'character)
 
@@ -942,8 +942,8 @@ annotate-actual-comment-end."
                                        export-buffer
                                      (current-buffer))))
       (with-current-buffer output-buffer
+        (erase-buffer)
         (when as-new-buffer
-          (erase-buffer)
           (funcall parent-buffer-mode))
         (cl-loop
          for buffer-line in buffer-lines
@@ -966,8 +966,8 @@ annotate-actual-comment-end."
                              (annotated-lines (annotate--split-lines (overlay-get overlay
                                                                                   'annotation)))
                              (ov-length       (- relative-end relative-start))
-                             (underline       (make-string (1- ov-length)
-                                                           annotate-integrate-higlight)))
+                             (underline       (make-string ov-length
+                                                           annotate-integrate-highlight)))
                         (insert (annotate-wrap-in-comment padding underline) "\n")
                         (when (annotate-chain-last-p overlay)
                           (when use-annotation-marker


### PR DESCRIPTION
Hi!

Unfortunately the command to integrate the annotations into the buffer's content was broken. :/ 
 This patch should fix the issue.

Bye!
C.