### PR TITLE
Prevented warning when saving a non annotated buffer

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,21 +1,42 @@
+2022-12-15 cage
+
+        * annotate.el:
+
+        - prevented printing of warning when saving a buffer that has no file
+          under the hood and no annotation.
+          `annotate-save-annotations' printed  a warning if the  buffer was not
+          based on a file's contents. But  the warning was printed even if the
+          buffer contained no annotations at all.
+          this patch prints the warning about  missing file only if the buffer
+          is annotated (i.e. contains at least an annotation).
+
+2022-11-30 cage
+
+        * Changelog,
+        * NEWS.org,
+        * annotate.el:
+
+        - increased version number;
+        - update NEWS.org and Changelog.
+
 2022-11-23 cage
 
-	* annotate.el:
+        * annotate.el:
 
-	- restored annotation of info files.
-	- renamed variable to respect a stylistic convention.
-	- do not skip 'annotate--remove-annotation-property' for narrowed
-	buffer.
-	Previously  the   function  above  just  skipped   narrowed  buffer,
-	effectively preventing delete of  annotation's text. This patch just
-	prevents the  function to try  to move  the cursor beyond  the buffer
-	limit that would leads to a crash.
-	The  test  for  narrowed  buffer was  added  because  command  like:
-	'comment-dwim' narrows the buffer beyond  the curtains, but my patch
-	was too  radical, this  changes supposed to  fix annotation  of info
-	files and does not interferes with 'comment-dwim'.
+        - restored annotation of info files.
+        - renamed variable to respect a stylistic convention.
+        - do not skip 'annotate--remove-annotation-property' for narrowed
+        buffer.
+        Previously  the   function  above  just  skipped   narrowed  buffer,
+        effectively preventing delete of  annotation's text. This patch just
+        prevent the  function to try  to move  the cursor beyond  the buffer
+        limit that would leads to a crash.
+        The  test  for  narrowed  buffer was  added  because  command  like:
+        'comment-dwim' narrows the buffer beyond  the curtains, but my patch
+        was too  radical, this  changes supposed to  fix annotation  of info
+        files and does not interferes with 'comment-dwim'.
 
-2022-11-22 cage2
+2022-11-22 cage
 
 
 	Merge pull request #140 from cage2/fix-tramp-crash

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,14 @@
+- 2022-12-15 v1.8.4 cage ::
+
+  This versions prevented printing of a warning
+
+  `annotate-save-annotations' printed a warning  if the buffer was not
+  based on a file's contents. But  the warning was printed even if the
+  buffer contained no annotations at all.
+
+  This  version prints  the warning  about  missing file  only if  the
+  buffer is annotated (i.e. contains at least an annotation).
+
 - 2022-11-30 v1.8.3 cage ::
 
   This versions fixed a bug that prevented annotations of info files.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 1.8.3
+;; Version: 1.8.4
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "1.8.3"
+  :version "1.8.4"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -1601,7 +1601,7 @@ essentially what you get from:
           (message "Annotations saved.")))
        ((annotate-indirect-buffer-current-p)
         (annotate--dump-indirect-buffer file-annotations))
-       (t
+       (file-annotations
         (lwarn '(annotate-mode)
                :warning
                annotate-warn-buffer-has-no-valid-file


### PR DESCRIPTION
Hi @bastibe !

A little patch to remove an annoying warning. :)

From NEWS.org

``` text
  This versions prevented printing of a warning

  `annotate-save-annotations' printed a warning  if the buffer was not
  based on a file's contents. But  the warning was printed even if the
  buffer contained no annotations at all.

  This  version prints  the warning  about  missing file  only if  the
  buffer is annotated (i.e. contains at least an annotation).
```

Bye!
C.