### PR TITLE
Saving color of each annotation in the database

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,19 +1,52 @@
-2023-09-25 cage <cage>
+2023-10-10 cage
 
-	* annotate.el:
+        * NEWS.org,
+        * annotate.el:
 
-	- fixed docstring.
-	- prevented using the same color on adjacent annotations;
-	To reproduce the issue (assuming the variable
-	'annotate-highlight-faces' is bound to a list of two elements):
+        - fixed procedure for coloring annotations (adjacent annotations with
+          the same colors was still possible).
+        - removed warning about unused parameter in function
+          'on-window-size-change';
+        - removed warnings about escaping in docstrings;
+        - used accented character instead of apostrophe.
+        - added saving of annotation face on the database.
+        - increased version number.
+        - updated NEWS file.
 
-	1. annotate the first line of a buffer (C-a)
-	2. annotate the second line of the same buffer (C-a)
-	3. delete the annotation on the second line (C-d)
-	4. annotate again the second line (C-a)
-	   the annotations in both lines got the same colors.
+2023-09-30 cage2
 
-	- fixed indentation of local functions definitions.
+
+        Merge pull request #158 from cage2/master
+
+2023-09-28 cage
+
+        * annotate.el:
+
+        - fixed points to start searching for adjacent annotations.
+
+2023-09-27 cage
+
+        * Changelog,
+        * NEWS.org,
+        * annotate.el:
+
+        - increased version number;
+        - updated NEWS file and changelog.
+
+2023-09-25 cage
+
+        * annotate.el:
+
+        - fixed docstring.
+        - prevented using the same color on adjacent annotations;
+        To     reproduce     the     issue    (assuming     the     variable
+        'annotate-highlight-faces' is bound to a list of two elements):
+        1. annotate the first line of a buffer (C-a)
+        2. annotate the second line of the same buffer (C-a)
+        3. delete the annotation on the second line (C-d)
+        4. annotate again the second line (C-a)
+        the annotations in both lines got the same colors.
+        - fixed indentation of local functions definitions.
 
 2023-08-09 cage
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,9 @@
+- 2023-10-10 v2.1.0 cage ::
+
+  This version ensures that the color scheme for each annotation (both
+  underline color of the annotated text and colors of the annotation),
+  is kept when reopening an annotated file.
+
 - 2023-09-27 v2.0.3 cage ::
 
   This version fixed a bug that could render with the same color two adjacent annotations.

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,8 +1,6 @@
 - 2023-10-10 v2.1.0 cage ::
 
-  This version ensures that the color scheme for each annotation (both
-  underline color of the annotated text and colors of the annotation),
-  is kept when reopening an annotated file.
+  This version ensures that the color theme for each annotation (both underline color of the annotated text and colors of the annotation), is saved when a an annotated file (or Emacs) is closed. The same color theme will be restored together with the annotations when, for example, the annotated file will be visited again.
 
 - 2023-09-27 v2.0.3 cage ::
 

--- a/README.org
+++ b/README.org
@@ -91,7 +91,7 @@ If point is the newline character and the customizable variable ~annotate-endlin
 
 If the line contains a single annotation that cover all the line, annotating the newline will ask to edit the annotation. If ~annotate-endline-annotate-whole-line~ is nil annotating a newline will signal an error.
 
-With a numeric prefix the annotations will be displayed with the faces indicated in ~annotate-endline-annotate-whole-line~ and ~annotate-annotation-text-faces~, respectively. The numeric prefix is used as index in the lists bound to the aforementioned variables.
+With a numeric prefix the annotations will be displayed with the faces indicated in ~annotate-highlight-faces~ and ~annotate-annotation-text-faces~, respectively. The numeric prefix is used as index in the lists bound to the aforementioned variables.
 
 The first theme can be addressed by the prefix ~1~, the second by the prefix ~2~ and so on.
 
@@ -101,6 +101,7 @@ The first theme can be addressed by the prefix ~1~, the second by the prefix ~2~
      - ~annotate-annotation-max-size-not-place-new-line~;
      - ~annotate-annotation-position-policy~;
      - ~annotate-endline-annotate-whole-line~;
+     - ~annotate-highlight-faces~;
      - ~annotate-annotation-text-faces~.
 
 *** ~C-c C-d~

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.0.3
+;; Version: 2.1.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.0.3"
+  :version "2.1.0"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -1,7 +1,7 @@
 ;;; annotate.el --- annotate files without changing them  -*- lexical-binding: t; -*-
 ;; Copyright (C) 2015 Bastian Bechtold and contributors:
 ;; Naoya Yamashita (2018)
-;; Universita' degli Studi di Palermo (2019)
+;; Università degli Studi di Palermo (2019)
 
 ;; Author: Bastian Bechtold
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
@@ -174,7 +174,7 @@ database file will be shown."
   :type 'boolean)
 
 (defcustom annotate-annotation-max-size-not-place-new-line 15
- "The maximum 'string-width' allowed for an annotation to be
+ "The maximum \"string-width\" allowed for an annotation to be
 placed on the right margin of the window instead of its own line
  after the annotated text."
   :type  'number)
@@ -456,7 +456,7 @@ See: `ANNOTATE-ANNOTATION-POSITION-POLICY'."
   (car (last chain)))
 
 (defun annotate--remap-chain-pos (annotations)
-  "Remap `ANNOTATIONS' as an annotation 'chain'.
+  "Remap `ANNOTATIONS' as an annotation \"chain\".
 
 An annotation is a collection of one or more overlays that
 contains the property `ANNOTATE-PROP-CHAIN-POSITION'.
@@ -492,7 +492,7 @@ belong."
         (annotate-annotation-set-chain-last last-element))))))
 
 (defun annotate-before-change-fn (a _b)
-  "This function is added to 'before-change-functions' hook and
+  "This function is added to \"before-change-functions\" hook and
 it is called any time the buffer content is changed (so, for
 example, text is added or deleted). In particular, it will
 rearrange the overlays bounds when an annotated text is
@@ -523,7 +523,7 @@ modified (for example a newline is inserted)."
   (annotate-load-annotations)
   (font-lock-flush))
 
-(defun on-window-size-change (frame)
+(defun on-window-size-change (_frame)
   "The function to call when window-size-change-functions is called,
 note that the argument `FRAME' is ignored"
   (font-lock-flush))
@@ -573,7 +573,7 @@ Used when the mode is activated."
                                #'annotate-timer-print-annotation-function))))
 
 (defun annotate--maybe-cancel-timer-print-annotation ()
-  "Cancel the timer to print the annotation's' text in the minibuffer.
+  "Cancel the timer to print the annotations text in the minibuffer.
 Used when the mode is deactivated."
   (when (and (annotate-print-annotation-under-cursor-p)
              annotate-echo-annotation-timer
@@ -620,7 +620,7 @@ Used when the mode is deactivated."
                                     (1 (annotate--change-guard)))))))
 
 (defun annotate-overlay-filled-p (overlay)
-  "Does this `OVERLAY' contains an 'annotation' property?"
+  "Does this `OVERLAY' contains an \"annotation\" property?"
   (and overlay
        (overlayp overlay)
        (overlay-get overlay 'annotation)))
@@ -1064,8 +1064,8 @@ An example might look like this:
 @@ -73,5 +73,5 @@
  ;;;###autoload
  (defface annotate-highlight
--  '((t (:underline \"coral\"))))
-+  '((t (:underline \"coral\"))))
+-  \\='((t (:underline \"coral\"))))
++  \\='((t (:underline \"coral\"))))
 #        ~~~~~~~~~~~~~~~~~~
 #        this doesn't work in cli
    \"Face for annotation highlights.\")
@@ -1083,11 +1083,11 @@ annotation, and can be conveniently viewed in diff-mode."
 
 The first match will get `ANNOTATE--CHANGE-GUARD' as its
 `INSERT-IN-FRONT-HOOK', to make sure that if a newline is inserted
-between the overlay and the annotation, the 'display' property of
+between the overlay and the annotation, the \"display\" property of
 the newline is properly disposed of.
 
 The second match will get `ANNOTATE--ANNOTATION-BUILDER' as its
-'display' property, which makes the newline look like an
+\"display\" property, which makes the newline look like an
 annotation plus the newline."
   (goto-char (next-overlay-change (point)))
   (if (>= (point) limit)
@@ -1260,7 +1260,7 @@ nil) the text is broken (regardless of words) to fit on the side
 of the window using `BEGIN-OF-LINE' `END-OF-LINE'.
 
 If annotation is a note that is placed in its own line the text is padded
-with spaces so that a 'box' surround the text without seams, e.g:
+with spaces so that a \"box\" surround the text without seams, e.g:
 
 aaa      aaa
 aa   ->  aa*
@@ -1306,7 +1306,7 @@ a        a**"
 
 (defun annotate--annotation-builder ()
   "Searches the line before point for annotations, and returns a
-'facespec' with the annotation in its 'display' property."
+\"facespec\" with the annotation in its \"display\" property."
   (save-excursion
     ;; (let ((newline-position (point)))
       (goto-char (1- (point))) ; we start at the start of the previous line
@@ -1533,14 +1533,14 @@ file."
   (cl-first record))
 
 (defun annotate-beginning-of-annotation (annotation)
-  "Get the starting point of an annotation. The arg 'annotation' must be a single
+  "Get the starting point of an annotation. The arg \"annotation\" must be a single
 annotation field got from a file dump of all annotated buffers,
 essentially what you get from:
 \(annotate-annotations-from-dump (nth index (annotate-load-annotations))))."
   (cl-first annotation))
 
 (defun annotate-ending-of-annotation (annotation)
-  "Get the ending point of an annotation. The arg 'annotation' must be a single
+  "Get the ending point of an annotation. The arg \"annotation\" must be a single
 annotation field got from a file dump of all annotated buffers,
 essentially what you get from:
 \(annotate-annotations-from-dump (nth index (annotate-load-annotations))))."
@@ -1573,7 +1573,7 @@ this function return is closed on the left and open on the right side."
                            (1- (annotate-ending-of-annotation annotation))))
 
 (defun annotate-annotation-string (annotation)
-  "Get the text of an annotation. The arg 'annotation' must be a single
+  "Get the text of an annotation. The arg \"annotation\" must be a single
 annotation field got from a file dump of all annotated buffers,
 essentially what you get from:
 \(annotate-annotations-from-dump (nth index (annotate-load-annotations))))."
@@ -1724,7 +1724,7 @@ ANNOTATED-TEXT:    the substring of buffer from START to END (as above)
 
 example:
 
-'(\"/foo/bar\" ((0 9 \"note\" \"annotated\")) hash-as-hex-string)."
+\\='(\"/foo/bar\" ((0 9 \"note\" \"annotated\")) hash-as-hex-string)."
   (interactive)
   (cl-labels ((old-format-p (annotation)
                 (not (stringp (cl-first (last annotation))))))
@@ -1767,12 +1767,12 @@ example:
 (defun annotate-db-clean-records (records-db)
   "Remove records from arg `RECORDS-DB' that have empty annotation, example:
 
-'((\"/foo/bar.dat\" nil \"abababababababababababababab\")
+\\='((\"/foo/bar.dat\" nil \"abababababababababababababab\")
   (\"/foo/baz.dat\" ((0 9 \"note\" \"annotated\")) \"abababababababababababababab\"))
 
 will become:
 
-'((\"/foo/baz.dat\" ((0 9 \"note\" \"annotated\")) \"abababababababababababababab\"))
+\\='((\"/foo/baz.dat\" ((0 9 \"note\" \"annotated\")) \"abababababababababababababab\"))
 
 i.e. the first record is removed."
   (cl-remove-if (lambda (a) (null (annotate-annotations-from-dump a)))
@@ -1926,7 +1926,7 @@ identified by the triplets `RECORD-FILENAME',
 
 In this context annotation means annotation loaded from local
 database not the annotation shown in the buffer (therefore these
-arguments are 'record' as called in the other database-related
+arguments are \"record\" as called in the other database-related
 functions)."
   (< (annotate-beginning-of-annotation a)
      (annotate-beginning-of-annotation b)))
@@ -2081,7 +2081,8 @@ the annotation's text will be rendered."
     (overlay-put last-ring 'hide-text nil)))
 
 (defun annotate-chain-hide-text-p (chain)
-"Non nil if the annotation's text contained in the last ring of `CHAIN' must not be rendered."
+  "Non nil if the annotation's text contained in the last ring of `CHAIN'
+must not be rendered."
   (let ((last-ring (annotate-chain-last (cl-first chain))))
     (annotate-tail-overlay-hide-text-p last-ring)))
 
@@ -2093,26 +2094,26 @@ the annotation's text will be rendered."
                                          &optional color-index)
   "Create a new annotation for selected region (from `START' to  `END'.
 
-Here the argument 'ANNOTATION-TEXT' is the string that appears
-on the margin of the window and 'annotated-text' is the string
+Here the argument `ANNOTATION-TEXT' is the string that appears
+on the margin of the window and \"annotated-text\" is the string
 that is underlined.
 
 If this function is called from procedure
-'annotate-load-annotations' the argument `ANNOTATED-TEXT'
+\"annotate-load-annotations\" the argument `ANNOTATED-TEXT'
 should be not null. In this case we know that an annotation
 existed in a text interval defined in the database
 metadata (the database located in the file specified by the
-variable 'annotate-file') and should just be
+variable \"annotate-file\") and should just be
 restored. Sometimes the annotated text (see above) can not be
 found in said interval because the annotated file's content
 changed and `annotate-mode' could not track the
 changes (e.g. save the file when annotate-mode was not
 active/loaded) in this case the matching
-text ('annotated-text') is searched in a region surrounding the
+text (\"annotated-text\") is searched in a region surrounding the
 interval and, if found, the buffer is annotated right there.
 
 The searched interval can be customized setting the variable:
-'annotate-search-region-lines-delta'."
+\"annotate-search-region-lines-delta\"."
   (cl-labels ((face-annotation-shifting-point (position shifting-direction-function)
                 (when-let* ((annotation       (funcall shifting-direction-function
                                                        position))
@@ -2581,7 +2582,7 @@ The format is suitable for database dump."
 
 (defun annotate-guess-file-format (filename)
   "Try to guess the file format from `FILENAME'.
-Non nil if the file format is supported from 'annotate' in a more
+Non nil if the file format is supported from \"annotate\" in a more
 sophisticated way than plain text."
   (cl-labels ((file-contents ()
                 (with-temp-buffer
@@ -2667,7 +2668,7 @@ sophisticated way than plain text."
         (annotate-mode  1)))))
 
 (defun annotate-summary-delete-annotation-button-pressed (button)
- "Callback for summary window fired when a 'delete' button is
+ "Callback for summary window fired when a \"delete\" button is
 pressed."
   (let* ((filename        (button-get button 'file))
          (beginning       (button-get button 'beginning))
@@ -2689,7 +2690,7 @@ pressed."
       (annotate-update-visited-buffer-maybe filename))))
 
 (defun annotate-summary-replace-annotation-button-pressed (button)
-  "Callback for summary window fired when a 'replace' button is
+  "Callback for summary window fired when a \"replace\" button is
 pressed."
   (let* ((filename             (button-get button 'file))
          (annotation-beginning (button-get button 'beginning))
@@ -2911,7 +2912,7 @@ summary window is shown.")
   "Holds the next token of the query in `ANNOTATE-SUMMARY-QUERY'.")
 
 (defun annotate-summary-query-lexer-symbol (res)
-  "The symbol identifying the token (e.g. 'and)."
+  "The symbol identifying the token (e.g. \\='and)."
   (elt res 0))
 
 (defun annotate-summary-query-lexer-string (res)
@@ -2942,21 +2943,21 @@ p.* and (a or not b)'
 
 will be broken into these tokens:
 
-'(re        \"p.*\"   0  3)
-'(and       \"and\"   4  7)
-'(open-par  \"(\"     8  9)
-'(re        \"a\"     9 10)
-'(or        \"or\"   11 12)
-'(not       \"not\"  14 17)
-'(re        \"b\"    18 19)
-'(close-par \"(\"    19 20)
+\\='(re        \"p.*\"   0  3)
+\\='(and       \"and\"   4  7)
+\\='(open-par  \"(\"     8  9)
+\\='(re        \"a\"     9 10)
+\\='(or        \"or\"   11 12)
+\\='(not       \"not\"  14 17)
+\\='(re        \"b\"    18 19)
+\\='(close-par \"(\"    19 20)
 
 The format is a proper list where:
 - first element
   a symbol representing the type of the token
-   - 're                  = regular expression
-   - 'and , 'or , 'not    = logical operator
-   - 'open-par, close-par = open and closing parenthesis respectively
+   - \\='re                  = regular expression
+   - \\='and , \\='or , \\='not    = logical operator
+   - \\='open-par, \\='close-par = open and closing parenthesis respectively
 - second element
   the value (the actual substring for this token)
 
@@ -2966,8 +2967,8 @@ The format is a proper list where:
 
 Note that spaces are ignored and all the tokens except `re' must
 not be prefixed with a backslash to match.  So, for example not ->
-will match the token type 'not but \not will match the token 're;
-this way we can 'protect' a regexp that contains reserved
+will match the token type \\='not but \not will match the token \\='re;
+this way we can \"protect\" a regexp that contains reserved
 keyword (aka escaping).
 
 The special value :no-more-token is returned after the whole
@@ -2977,13 +2978,13 @@ Calling this function with value of LOOK-AHEAD-P nil will `CONSUME' the
 token from `annotate-summary-query' (i.e. that string is modified).
 
 example:
-'a and b' -> 'and b', '(re \"a\" 0 1)
+\"a and b\" -> \"and b\", \\='(re \"a\" 0 1)
 
 when LOOK-AHEAD-P is not nil the token is recognized but not cut away
 from `annotate-summary-query'.
 
 example:
-'a and b' -> 'a and b', '(re \"a\" 0 1)"
+\"a and b\" -> \"a and b\", \\='(re \"a\" 0 1)"
   (cl-labels ((build-token (token-symbol token-string token-beginning token-end)
                 (list token-symbol
                       token-string
@@ -3031,7 +3032,7 @@ example:
   (eq token :no-more-tokens))
 
 (defun annotate-summary-token-symbol-match (looking-symbol token)
-  "Return non nil if `LOOKING-SYMBOL' is 'eq' to the symbol
+  "Return non nil if `LOOKING-SYMBOL' is \"eq\" to the symbol
 component of `TOKEN'."
   (eq looking-symbol
       (annotate-summary-query-lexer-symbol token)))
@@ -3041,7 +3042,7 @@ component of `TOKEN'."
 
 This function will parse the following production rules
 
-NOTE       := '(' NOTE ')'
+NOTE       := \"(\" NOTE \")\"
                | NOTE OPERATOR NOTE
                | NOT NOTE
                | RE
@@ -3054,15 +3055,15 @@ ESCAPED-RE := DELIMITER
               ANYTHING
               DELIMITER
 ANYTHING   := .*           ; as a regular expression
-AND        := 'and'
-OR         := 'or'
-NOT        := 'not'
+AND        := \"and\"
+OR         := \"or\"
+NOT        := \"not\"
 DELIMITER  := \" ; ASCII 34 (dec) 22 (hex)
 
 Arguments:
 
 - filter-fn is a function that accept two parameters: the regular
-  expression to match (a token of type 're, see the lexer
+  expression to match (a token of type \\='re, see the lexer
   `ANNOTATE-SUMMARY-LEXER' and a single annotation record (see
   `ANNOTATE-LOAD-ANNOTATIONS').
 
@@ -3202,7 +3203,7 @@ EXPRESSION := FILE-MASK
                | FILE-MASK AND NOTE
                | FILE-MASK OR NOTE
                | epsilon
-NOTE       := '(' NOTE ')'
+NOTE       := \"(\" NOTE \")\"
                | NOTE OPERATOR NOTE
                | NOT NOTE
                | RE
@@ -3215,9 +3216,9 @@ ESCAPED-RE := DELIMITER
               ANYTHING
               DELIMITER
 ANYTHING   := .*           ; as a regular expression
-AND        := 'and'
-OR         := 'or'
-NOT        := 'not'
+AND        := \"and\"
+OR         := \"or\"
+NOT        := \"not\"
 DELIMITER  := \" ; ASCII 34 (dec) 22 (hex)
 
 Note: this function returns the annotation part of the record, see
@@ -3326,13 +3327,13 @@ where
 Examples:
 
 - lisp$ and TODO
- matches the text 'TODO' in all lisp files
+ matches the text \"TODO\" in all lisp files
 
 Parenthesis can be used for the expression related to the text of
 annotation, like this:
 
 - lisp$ and (TODO or important)
- the same as above but checks also for string 'important'
+ the same as above but checks also for string \"important\"
 
 - /home/foo/
  matches all the annotation that refers to file in the directory
@@ -3340,13 +3341,13 @@ annotation, like this:
 
 - /home/foo/ and not minor
  matches all the annotation that refers to file in the directory
- '/home/foo' and that not contains the text 'minor'.
+ '/home/foo' and that not contains the text \"minor\".
 
 - .* and \"not\"
  the \" can be used to escape strings
 
 If you want to remove from summary the annotations that appears
-before a position in buffer set 'remove-annotations-cutoff-point' to said
+before a position in buffer set \"remove-annotations-cutoff-point\" to said
 position.
 
 The annotations in each record are sorted by starting point in ascending order."


### PR DESCRIPTION
Hi @bastibe !

I thought, given that an user can specify the color theme for each annotation, could be a good idea to save this information in the database, making the change persistent so that can be restored later. The database format has changed but the change is backward compatible (but i will recheck tomorrow, just in case! :smile: ).

Bye!
C.