### PR TITLE
Added commands to force positioning and color of an annotation

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,17 +1,59 @@
+2024-03-13 cage
+
+	* README.org,
+	* annotate.el:
+
+	- added new command 'annotate-change-annotation-color';
+	- printed message with current policy for annotation when changing
+	positioning. using 'annotate-change-annotation-text-position';
+	- update keymap to accomodate new commands.
+	- fixed variable name.
+	- updated docstrings.
+	- updated README.
+	- changed keybinding for 'annotate-change-annotation-text-position';
+	- added missing docstring.
+	- increased version number.
+
+2024-03-07 cage
+
+	* annotate.el:
+
+	- allowed different positioning of annotated text on the same buffer.
+	- added command 'annotate-change-annotation-text-position'.
+	- fixed position policy layout in builder.
+	- fixed wrapping of annotation in a 'box'.
+
+2024-03-05 cage
+
+	* annotate.el:
+
+	- preferred wrapping functions instead of call to 'overlay-put' and
+	'overlay-get'.
+
+2023-11-02 cage
+
+
+	Merge pull request #159 from cage2/master
+
 2023-10-10 cage
 
-        * NEWS.org,
-        * annotate.el:
+	* Changelog,
+	* NEWS.org,
+	* README.org,
+	* annotate.el:
 
-        - fixed procedure for coloring annotations (adjacent annotations with
-          the same colors was still possible).
-        - removed warning about unused parameter in function
-          'on-window-size-change';
-        - removed warnings about escaping in docstrings;
-        - used accented character instead of apostrophe.
-        - added saving of annotation face on the database.
-        - increased version number.
-        - updated NEWS file.
+	- fixed procedure for coloring annotations (adjacent annotations with
+	the same colors was still possible).
+	- removed warning about unused parameter in function
+	'on-window-size-change';
+	- removed warnings about escaping in docstrings;
+	- used accented character instead of apostrophe.
+	- added saving of annotation face on the database.
+	- increased version number.
+	- updated NEWS file.
+	- updated Changelog.
+	- rephrased NEWS file entry.
+	- fixed README.
 
 2023-09-30 cage2
 
@@ -105,7 +147,7 @@
 
         Merge pull request #150 from cage2/hide-annotation-text
 
-2023-02-22 cage <cage>
+2023-02-22 cage
 
         * Changelog,
         * NEWS.org,

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,12 @@
+- 2023-10-10 v2.2.0 cage ::
+
+  This version adds two new commands:
+
+  - annotate-change-annotation-text-position;
+  - annotate-change-annotation-colors.
+
+  To force positioning or color, respectively, for a single annotation.
+
 - 2023-10-10 v2.1.0 cage ::
 
   This version ensures that the color theme for each annotation (both underline color of the annotated text and colors of the annotation), is saved when a an annotated file (or Emacs) is closed. The same color theme will be restored together with the annotations when, for example, the annotated file will be visited again.

--- a/README.org
+++ b/README.org
@@ -131,6 +131,18 @@ The annotation text can be pressed to and will open the annotated file, placing 
 **** related customizable variable
      - ~annotate-summary-ask-query~.
 
+*** ~C-c C-c~ (function annotate-change-annotation-colors)
+
+Change the color of the annotation below point (both higlight and annotation text colors are changed).
+
+These changes are kept after the buffer is killed.
+
+*** ~C-c C-p~ (function annotate-change-annotation-text-position)
+
+Change the policy positioning the annotation below point, a message with the new policy is printed.
+
+These changes are kept after the buffer is killed.
+
 * Exporting
 
 Annotations can be exported ~annotate-export-annotations~ as commented unified diffs, like this:

--- a/annotate.el
+++ b/annotate.el
@@ -66,7 +66,7 @@
     (define-key map (kbd "C-c C-a") #'annotate-annotate)
     (define-key map (kbd "C-c C-d") #'annotate-delete-annotation)
     (define-key map (kbd "C-c C-.") #'annotate-change-annotation-text-position)
-    (define-key map (kbd "C-c C-c")  #'annotate-change-annotation-colors)
+    (define-key map (kbd "C-c C-c") #'annotate-change-annotation-colors)
     (define-key map (kbd "C-c C-s") #'annotate-show-annotation-summary)
     (define-key map (kbd "C-c ]")   #'annotate-goto-next-annotation)
     (define-key map (kbd "C-c [")   #'annotate-goto-previous-annotation)
@@ -2334,7 +2334,7 @@ and `annotate-color-index-from-dump' to specify annotation appearance."
               (if (and text-to-match
                        (string= text-to-match annotated-text))
                   (create-annotation start end annotation-text)
-                (let* ((starting-point-macthing (go-backward start))
+                (let* ((starting-point-matching (go-backward start))
                        (ending-point-match      (go-forward  start))
                        (length-match            (- end start))
                        (new-match               (guess-match-and-add starting-point-matching

--- a/annotate.el
+++ b/annotate.el
@@ -1379,10 +1379,11 @@ a        a**"
                             :new-line
                           :margin)
                       position)))
-            (let* ((multiline-annotation (annotate-wrap-annotation-in-box ov
+            (let* ((wrap-in-a-new-line   (eq new-position-policy :new-line))
+                   (multiline-annotation (annotate-wrap-annotation-in-box ov
                                                                           bol
                                                                           eol
-                                                                          new-position-policy))
+                                                                          wrap-in-a-new-line))
                    (annotation-stopper   (if (not (eq new-position-policy
                                                       :margin))
                                              (if (= overlays-counter

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.1.0
+;; Version: 2.2.0
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.1.0"
+  :version "2.2.0"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -444,18 +444,24 @@ position (so that it is unchanged after this function is called)."
   (overlay-get annotation 'annotation-face))
 
 (defun annotate-annotation-set-annotation-text (annotation annotation-text)
+  "Set the annotation's content for `ANNOTATION` to `ANNOTATION-TEXT`."
   (overlay-put annotation 'annotation annotation-text))
 
 (defun annotate-annotation-get-annotation-text (annotation)
+  "Get the annotation's content for `ANNOTATION`."
   (overlay-get annotation 'annotation))
 
 (defun annotate-annotation-set-position (annotation position)
+  "Set the annotation's position policy for `ANNOTATION` to the value bound to `POSITION`."
   (overlay-put annotation 'annotate-position position))
 
 (defun annotate-annotation-get-position (annotation)
+  "Get the annotation's position policy for `ANNOTATION`."
   (overlay-get annotation 'annotate-position))
 
 (defun annotate-overlay-maybe-set-position (overlay position)
+  "Set the annotation's position policy for `ANNOTATION` to the value bound to `POSITION`,
+but only if the value of the property 'position is not null."
   (when position
     (annotate-annotation-set-position overlay position)))
 
@@ -939,6 +945,7 @@ and
         (annotate-goto-previous-annotation :startingp t)))))
 
 (defun annotate-change-annotation-text-position ()
+  "Change the policy positioning for the annotation under point."
   (interactive)
   (when-let ((annotation (annotate-annotation-at (point))))
     (let ((current-position (annotate-annotation-get-position annotation)))
@@ -957,6 +964,7 @@ and
     (font-lock-flush)))
 
 (defun annotate-change-annotation-colors ()
+  "Change the colors for the annotation under point."
   (interactive)
   (cl-flet ((new-color-index (annotation)
               (let ((current-annotation-face (annotate-annotation-property-annotation-face annotation)))
@@ -2184,14 +2192,14 @@ that is underlined.
 
 If this function is called from procedure
 \"annotate-load-annotations\" the argument `ANNOTATED-TEXT'
-should be not null. In this case we know that an annotation
+should be not null.  In this case we know that an annotation
 existed in a text interval defined in the database
 metadata (the database located in the file specified by the
 variable \"annotate-file\") and should just be
-restored. Sometimes the annotated text (see above) can not be
+restored.  Sometimes the annotated text (see above) can not be
 found in said interval because the annotated file's content
 changed and `annotate-mode' could not track the
-changes (e.g. save the file when annotate-mode was not
+changes (e.g. save the file when `annotate-mode' was not
 active/loaded) in this case the matching
 text (\"annotated-text\") is searched in a region surrounding the
 interval and, if found, the buffer is annotated right there.
@@ -2199,9 +2207,11 @@ interval and, if found, the buffer is annotated right there.
 The searched interval can be customized setting the variable:
 \"annotate-search-region-lines-delta\".
 
-Finally `COLOR-INDEX`, if non-null (default nil), is used as index to address
+`COLOR-INDEX`, if non-null (default nil), is used as index to address
 elements both in `annotate-color-index-from-dump'
-and `annotate-color-index-from-dump' to specify annotation appearance."
+and `annotate-color-index-from-dump' to specify annotation appearance.
+
+Finally `POSITION` indicates the positioning policy for the annotation, if null the value bound to `annotate-annotation-position-policy` is used."
   (cl-labels ((face-annotation-shifting-point (position shifting-direction-function)
                 (when-let* ((annotation       (funcall shifting-direction-function
                                                        position))

--- a/annotate.el
+++ b/annotate.el
@@ -65,7 +65,7 @@
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "C-c C-a") #'annotate-annotate)
     (define-key map (kbd "C-c C-d") #'annotate-delete-annotation)
-    (define-key map (kbd "C-c C-.") #'annotate-change-annotation-text-position)
+    (define-key map (kbd "C-c C-p") #'annotate-change-annotation-text-position)
     (define-key map (kbd "C-c C-c") #'annotate-change-annotation-colors)
     (define-key map (kbd "C-c C-s") #'annotate-show-annotation-summary)
     (define-key map (kbd "C-c ]")   #'annotate-goto-next-annotation)
@@ -182,7 +182,8 @@ placed on the right margin of the window instead of its own line
   :type  'number)
 
 (defconst annotate-allowed-positioning-policy
-  '(:by-length :margin :new-line))
+  '(:by-length :margin :new-line)
+  "The allowed values for annotation positioning")
 
 (defcustom annotate-annotation-position-policy :by-length
   "Policy for annotation's position:


### PR DESCRIPTION
Hi @bastibe !

How are you?

I have added two commands to set the color or the positioning for each annotation, changes are persistent, as you can guess, this means the the format of the annotation database has changed again :sweat_smile:; By the way the changes are backward compatible, fortunately!

Bye!
C.