### PR TITLE
Fixed wrong coloration for adjacent annotations

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,42 @@
+2024-05-08 cage
+
+	* annotate.el:
+
+	- increased version number.
+
+2024-04-17 cage
+
+	* annotate.el:
+
+	- fixed color's annotation when the new annotated text end border lays
+	just next to an already annotated text
+	for example:
+	foo-bar
+	⏶  ^^^ ← annotated text
+	|
+	`cursor position
+	annotating  "foo-"  ("C-c  C-a")  would  set a  color  for  the  new
+	annotation  equals to  the one  on the  left, the  correct behaviour
+	would be to set a different color.
+
+2024-03-23 cage
+
+	* NEWS.org,
+	* annotate.el:
+
+	- increased version number;
+	- added missing information from docstring;
+	- updated NEWS.org.
+
+2024-03-20 cage2
+
+
+	Merge pull request #160 from cage2/master
+
 2024-03-13 cage
 
+	* Changelog,
+	* NEWS.org,
 	* README.org,
 	* annotate.el:
 
@@ -13,6 +50,8 @@
 	- changed keybinding for 'annotate-change-annotation-text-position';
 	- added missing docstring.
 	- increased version number.
+	- updated changelog.
+	- updated NEWS.
 
 2024-03-07 cage
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2024-05-08 v2.2.2 cage ::
+
+  This version fixed wrong coloration for adjacent annotations.
+
 - 2024-03-23 v2.2.1 cage ::
 
   This version added missing information from documentation about annotations database file format.

--- a/annotate.el
+++ b/annotate.el
@@ -2226,7 +2226,8 @@ Finally `POSITION` indicates the positioning policy for the annotation, if null 
                 (face-annotation-shifting-point position
                                                 #'annotate-previous-annotation-ends))
               (face-annotation-after-point (position)
-                (face-annotation-shifting-point position
+		(face-annotation-shifting-point (max (point-min)
+						     (1- position))
                                                 #'annotate-next-annotation-starts))
               (available-face-index (&rest used-faces)
                 (cl-position-if-not (lambda (a)

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.2.1
+;; Version: 2.2.2
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.2.1"
+  :version "2.2.2"
   :group 'text)
 
 (defvar annotate-mode-map


### PR DESCRIPTION
Hi @bastibe !

A minor (but annoying) bug fixed  (I fear won't be the last one! :smile: :smile:). 

Bye!
C.

----------------

Example:

``` text
  foo-bar
   ⏶  ^^^ ← annotated text
   |
   `cursor position
```
annotating  "foo-"  ("C-c  C-a")  would  set a  color  for  the  new annotation  equals to  the one  on the  left, the  correct behavior
would be to set a different color.