### PR TITLE
Prevented annotating text on the last line with no newline

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,8 +1,25 @@
-2024-05-08 cage
+2024-10-10 cage
 
 	* annotate.el:
 
+	- prevented an annotation to appears on the last line of a buffer if
+	the buffer does not ends with a newline character.
+	- increased version number;
+	- changed '(C) with the copyright character.
+
+2024-05-09 cage2
+
+
+	Merge pull request #162 from cage2/master
+
+2024-05-08 cage
+
+	* Changelog,
+	* NEWS.org,
+	* annotate.el:
+
 	- increased version number.
+	- updated news and changelog files.
 
 2024-04-17 cage
 

--- a/Changelog
+++ b/Changelog
@@ -1,11 +1,23 @@
+2024-10-16 cage
+
+        * NEWS.org,
+        * annotate.el:
+
+        - added the chance to append a newline character at the end of a
+        buffer when it does not terminate with a proper line;
+        - updated news file.
+
 2024-10-10 cage
 
-	* annotate.el:
+        * Changelog,
+        * NEWS.org,
+        * annotate.el:
 
-	- prevented an annotation to appears on the last line of a buffer if
-	the buffer does not ends with a newline character.
-	- increased version number;
-	- changed '(C) with the copyright character.
+        - prevented an annotation to appears on the last line of a buffer if
+        the buffer does not ends with a newline character;
+        - increased version number;
+        - changed '(C) with the copyright character;
+        - updated News file and Changelog.
 
 2024-05-09 cage2
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2024-10-10 v2.2.3 cage ::
+
+  This version prevents to annotate the last line of a buffer if such buffer does not terminates with a new line character (in previous versions the annotated text was highlighted but the annotation text was not shown).
+
 - 2024-05-08 v2.2.2 cage ::
 
   This version fixed wrong coloration for adjacent annotations.

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,6 +1,6 @@
 - 2024-10-10 v2.2.3 cage ::
 
-  This version prevents to annotate the last line of a buffer if such buffer does not terminates with a new line character (in previous versions the annotated text was highlighted but the annotation text was not shown).
+  This version contains code that asks the user to append a newline character to the end of a buffer if such buffer does not terminates with a newline character (if the newline is not present the annotated text is highlighted but the annotation text is not shown).
 
 - 2024-05-08 v2.2.2 cage ::
 

--- a/annotate.el
+++ b/annotate.el
@@ -1,5 +1,5 @@
 ;;; annotate.el --- annotate files without changing them  -*- lexical-binding: t; -*-
-;; Copyright (C) 2015 Bastian Bechtold and contributors:
+;; Copyright © 2015 Bastian Bechtold and contributors:
 ;; Naoya Yamashita (2018)
 ;; Università degli Studi di Palermo (2019)
 
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.2.2
+;; Version: 2.2.3
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.2.2"
+  :version "2.2.3"
   :group 'text)
 
 (defvar annotate-mode-map


### PR DESCRIPTION
Hi @bastibe !

I do not usually allow a file to terminate without a newline character, but sometimes I make a mistake and, this time, i discovered this bug! :smiley: 

In previous version annotating the last "line" of a buffer that does not ends with a newline just underlined the annotated text without showing the annotation text; now an error is printed on the minibuffer, instead.

Bye!  
C.

