### PR TITLE
Optimize searching for annotations

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,10 +1,30 @@
+2025-03-19 cage
+
+	* annotate.el:
+
+	- optimized 'annotate-annotations-overlay-in-range' by jumping from an
+	annotation to another, instead of scanning every single character of
+	the buffer.
+
+2025-03-06 cage
+
+
+	Merge pull request #166 from
+	cage2/updating-documentation-after-autosave-patch
+
 2025-03-05 cage
 
-        * README.org:
+	* Changelog,
+	* NEWS.org,
+	* README.org,
+	* annotate.el:
 
-        Merge pull request #165 from krvkir/master
-        - fixed typo in README.
-        - updated README.
+	Merge pull request #165 from krvkir/master
+	- fixed typo in README.
+	- updated README.
+	- updated Changelog.
+	- increased version number;
+	- updated NEWS file.
 
 2025-03-02 krvkir
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2025-03-05 v2.3.1 cage ::
+
+  This version optimizes a function that searches for annotations in a buffer; this changes should speed up commands like ~annotate-toggle-all-annotations-text~.
+
 - 2025-03-05 v2.3.0 krvkir ::
 
   This version adds a new customizable variable to instructs annotate.el to save annotation's database each time a new annotation is created, deleted or amended.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.3.0
+;; Version: 2.3.1
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -58,7 +58,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.3.0"
+  :version "2.3.1"
   :group 'text)
 
 (defvar annotate-mode-map
@@ -906,7 +906,7 @@ and
     (font-lock-flush)))
 
 (defun annotate-toggle-all-annotations-text ()
-"Hide annototation's text in the whole buffer."
+"Hide annotation's text in the whole buffer."
   (interactive)
   (let ((chains (annotate-annotations-chain-in-range 0 (buffer-size))))
     (dolist (chain chains)

--- a/annotate.el
+++ b/annotate.el
@@ -1501,18 +1501,21 @@ surrounded by `BEGIN' and `END'."
 (defun annotate-annotations-overlay-in-range (from-position to-position)
   "Return the annotations overlays that are enclosed in the range
 defined by `FROM-POSITION' and `TO-POSITION'."
-  (let ((annotations ()))
-    (cl-loop for  i
-             from (max 0 (1- from-position))
-             to   to-position
-             do
-      (let ((annotation (annotate-next-annotation-starts i)))
-        (annotate-ensure-annotation (annotation)
-          (let ((chain-end   (overlay-end   (annotate-chain-last  annotation)))
-                (chain-start (overlay-start (annotate-chain-first annotation))))
-            (when (and (>= chain-start from-position)
-                       (<= chain-end   to-position))
-              (cl-pushnew annotation annotations))))))
+  (let ((annotations ())
+	(counter (max 0 (1- from-position))))
+    (catch 'scan-loop
+      (while (<= counter
+                 to-position)
+	(cl-incf counter)
+	(let ((annotation (annotate-next-annotation-starts counter)))
+          (if (annotationp annotation)
+              (let ((chain-end   (overlay-end   (annotate-chain-last  annotation)))
+                    (chain-start (overlay-start (annotate-chain-first annotation))))
+		(setf counter chain-end)
+		(when (and (>= chain-start from-position)
+			   (<= chain-end   to-position))
+		  (cl-pushnew annotation annotations)))
+	    (throw 'scan-loop t)))))
     (reverse annotations)))
 
 (defun annotate-annotations-chain-in-range (from-position to-position)


### PR DESCRIPTION
Hi!

the function `annotate-annotations-overlay-in-range` is sadly inefficient (see: https://github.com/bastibe/annotate.el/issues/167#issuecomment-2708983595), this patch optimize the scanning loop; for comparison, this is the time spent by Emacs calling `(annotate-toggle-all-annotations-text)` when performed on the `annotate.el` source code file with a single annotation:

``` text
Elapsed time: 5.043135s (3.782171s in 175 GCs)
```

This is the same function called with the patched code:

``` text
Elapsed time: 0.000276s
```

If I have not introduced new bugs :sweat_smile: , looks a good improvements.

Bye!
C.