### PR TITLE
Added annotation's text expansion feature

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,10 +1,19 @@
+2025-03-20 cage
+
+	Merge pull request #168 from cage2/optimize-searching-for-annotations
+
 2025-03-19 cage
 
+	* Changelog,
+	* NEWS.org,
 	* annotate.el:
 
 	- optimized 'annotate-annotations-overlay-in-range' by jumping from an
 	annotation to another, instead of scanning every single character of
 	the buffer.
+	- increased version number;
+	- updated NEWS file and changelog;
+	- fixed docstring.
 
 2025-03-06 cage
 

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,11 @@
+- 2025-04-23 v2.4.0 cage ::
+
+  This version adds annotation's text expansion feature:
+
+  #+BEGIN_SRC text
+  "%d foo" → "2025-04-23 foo"
+  #+END_SRC
+
 - 2025-03-05 v2.3.1 cage ::
 
   This version optimizes a function that searches for annotations in a buffer; this changes should speed up commands like ~annotate-toggle-all-annotations-text~.

--- a/README.org
+++ b/README.org
@@ -221,6 +221,20 @@ Shows or hides the annotation's text in the whole buffer.
 **  annotate-autosave
 Whether annotations should be saved after each user action, e.g. new annotation created, existing one amended or deleted. Boolean value, default is ~nil~ i.e. do not perform autosave and update the annotations in a buffer, just after killing buffer or quitting Emacs.
 
+** annotate-annotation-expansion-map
+
+The Expansion map for the annotation text. If a substring  in the annotation text matches the string in the car value of each cons cell of this alist, it is expanded with the results of  passing the cdr of each cell to a system shell. Example below.
+
+The expression:
+
+#+BEGIN_SRC lisp
+  (setf annotate-annotation-expansion-map
+	'(("%d" . "date +%Y-%m-%d")))
+#+END_SRC
+
+Will expand any occurrence of "%d" in the annotation's text with
+the current date (format: "YYYY-MM-DD").
+
 * More documentation
 
 Please check ~M-x customize-group RET annotate~ as there is extensive documentation for each customizable variable.

--- a/README.org
+++ b/README.org
@@ -223,17 +223,16 @@ Whether annotations should be saved after each user action, e.g. new annotation 
 
 ** annotate-annotation-expansion-map
 
-The Expansion map for the annotation text. If a substring  in the annotation text matches the string in the car value of each cons cell of this alist, it is expanded with the results of  passing the cdr of each cell to a system shell. Example below.
+The expansion map for the annotation text. If a substring in the annotation text matches the string in the first item of each element of this list, it will be expanded with the results of passing the second item — as a command — to a system shell, if the third item is not null, the output string of the command's results will be trimmed (spaces or some others non printable characters will be removed from both ends, see: `string-trim'). Example below.
 
 The expression:
 
 #+BEGIN_SRC lisp
   (setf annotate-annotation-expansion-map
-	'(("%d" . "date +%Y-%m-%d")))
+	'((\"%d\" \"date +%Y-%m-%d\" t)))
 #+END_SRC
 
-Will expand any occurrence of "%d" in the annotation's text with
-the current date (format: "YYYY-MM-DD").
+Will expand any occurrence of \"%d\" in the annotation's text with the current date (format: \"YYYY-MM-DD\"), moreover the results will be trimmed.
 
 * More documentation
 

--- a/annotate.el
+++ b/annotate.el
@@ -251,7 +251,7 @@ of lines. The center of the region is the position of the
 annotation as defined in the database."
   :type 'number)
 
-(defcustom annotate-autosave nil
+(defcustom annotate-autosave t
   "Whether annotations should be saved after each user action,
 e.g. new annotation created, existing one amended or deleted."
   :type 'boolean)

--- a/annotate.el
+++ b/annotate.el
@@ -256,7 +256,7 @@ annotation as defined in the database."
 e.g. new annotation created, existing one amended or deleted."
   :type 'boolean)
 
-(defcustom annotate-annotation-expansion-map '(("%d" . "date +%Y-%m-%d"))
+(defcustom annotate-annotation-expansion-map '()
   "The expansion map for the annotation text. If a substring  in the annotation text matches the string in the car value of each cons cell of this alist, it is expanded with the results of  passing the cdr of each cell to a system shell. Example below.
 
 The expression:


### PR DESCRIPTION
Hi!

This PR add a new feature: a string matching a regular expression in the annotation's text may be replaced with the output of a customizable shell command, e.g.

``` lisp
(\"%d\" \"date +%Y-%m-%d\" t)
```

will expand the sub string `%d` with the results of running the command `date +%Y-%m-%d`, that is

``` text
"%d foo" → "2025-04-23 foo"
```

The last element on the list is a boolean that indicates if the command must be trimmed using `string-trim`.

Also, please note that i have flipped `annotate-autosave` from `nil` to `t`, because i found it a very useful feature! :smile: 

Bye!
C.
