### PR TITLE
abbreviated buffer's file name to allow annotating remote file using TRAMP mode

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,8 +1,38 @@
-2025-05-14 cage
+2025-11-01 cage
 
 	* annotate.el:
 
+	- wrapped 'file-exists-p' with 'ignore-errors' to catch TRAMP
+	connection errors.
+	- fixed docstring for 'annotate-file-exists-p'.
+
+2025-10-31 cage
+
+	* annotate.el:
+
+	- abbreviated buffer's file name to allow annotating remote file using
+	TRAMP mode;
+	- fixed indentation and moved function definition.
+
+2025-05-15 cage
+
+	* annotate.el:
+
+	- added missing docstring for 'annotate--expand-annotation-text';
+	- fixed other two docstrings.
+
+2025-05-14 cage
+
+	* Changelog,
+	* Eask,
+	* NEWS.org,
+	* annotate.el:
+
 	- fixed docstrings.
+	- increased version number;
+	- updated NEWS file;
+	- updated Changelog.
+	- increased version number in eask file.
 
 2025-05-12 cage2
 

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "annotate"
-         "2.4.2"
+         "2.4.3"
          "annotate files without changing them")
 
 (website-url "https://github.com/bastibe/annotate.el")

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2025-11-01 v2.4.3 cage ::
+
+  This version fixed a bug that prevented remote file to be annotated.
+
 - 2025-05-09 v2.4.2 cage ::
 
   This versions adds a CI system and boilerplate for adding unit testing to annotate.el (thanks JenChieh!); also docstrings has been modified to be more compliant to Emacs documentation standards.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.4.2
+;; Version: 2.4.3
 ;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is NOT part of GNU Emacs.
@@ -59,7 +59,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.4.2"
+  :version "2.4.3"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -418,7 +418,9 @@ in the customizable colors lists:
          (read-only-mode 1)))))
 
 (defun annotate-file-exists-p (filepath)
-  "Returns nil if the file pointed by `FILEPATH' does not exists or en error occurs during the test (e.g TRAMP mode fails to connect to remote server."
+  "Returns nil if the file pointed by `FILEPATH' does not exists
+or an error occurs during the test
+(e.g TRAMP mode fails to connect to remote server)."
   (ignore-errors (file-exists-p filepath)))
 
 (defun annotate-annotations-exist-p ()


### PR DESCRIPTION
Hi @bastibe !

I hope you are doing well!

I started using TRAMP mode lately and I noted that annotate-mode was unable to annotate remote files.

Fortunately seems that there was just an inconsistency between the file name saved on the database (that was abbreviated) and the one got from the buffer using `annotate-actual-file-name` (that was not abbreviated).

This patch try to fix this issue.

Bye!
C.