### PR TITLE
Changed 'ignore-errors' with 'with-demoted-errors'

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,10 +1,22 @@
+2025-11-02 cage
+
+	* annotate.el:
+
+	- changed (in function 'annotate-file-exists-p') 'ignore-errors' with:
+	'with-demoted-errors', to convert errors to message.
+
 2025-11-01 cage
 
+	* Changelog,
+	* Eask,
+	* NEWS.org,
 	* annotate.el:
 
 	- wrapped 'file-exists-p' with 'ignore-errors' to catch TRAMP
 	connection errors.
 	- fixed docstring for 'annotate-file-exists-p'.
+	- increased version number;
+	- updated Changelog and NEWS files.
 
 2025-10-31 cage
 

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "annotate"
-         "2.4.3"
+         "2.4.4"
          "annotate files without changing them")
 
 (website-url "https://github.com/bastibe/annotate.el")

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2025-11-02 v2.4.4 cage ::
+
+  This version informs the user when an error occurred while checking the existence of an annotated file.
+
 - 2025-11-01 v2.4.3 cage ::
 
   This version fixed a bug that prevented remote file to be annotated.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.4.3
+;; Version: 2.4.4
 ;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is NOT part of GNU Emacs.
@@ -59,7 +59,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.4.3"
+  :version "2.4.4"
   :group 'text)
 
 (defvar annotate-mode-map

--- a/annotate.el
+++ b/annotate.el
@@ -421,7 +421,8 @@ in the customizable colors lists:
   "Returns nil if the file pointed by `FILEPATH' does not exists
 or an error occurs during the test
 (e.g TRAMP mode fails to connect to remote server)."
-  (ignore-errors (file-exists-p filepath)))
+  (with-demoted-errors "Error: %S"
+    (file-exists-p filepath)))
 
 (defun annotate-annotations-exist-p ()
   "Does this buffer contains at least one or more annotations?"


### PR DESCRIPTION
Following the suggestion of an Emacs maintainer, i used `with-demoted-errors` in `annotate-file-exists-p` because, this way, an error message is printed when an error occurs while testing for a file existence (even the error is still ignored).