### PR TITLE
removed expansion of file paths when deserializing annotations records

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,9 +1,23 @@
+2025-11-11 cage
+
+	* annotate.el:
+
+	- removed expansion of file paths when deserializing annotations
+	records;
+	- moved to local function code for record's deserialization.
+
 2025-11-02 cage
 
+	* Changelog,
+	* Eask,
+	* NEWS.org,
 	* annotate.el:
 
 	- changed (in function 'annotate-file-exists-p') 'ignore-errors' with:
 	'with-demoted-errors', to convert errors to message.
+	- increased version number;
+	- updated NEWS and Changelog files.
+	Merge pull request #175 from cage2/master
 
 2025-11-01 cage
 

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "annotate"
-         "2.4.4"
+         "2.4.5"
          "annotate files without changing them")
 
 (website-url "https://github.com/bastibe/annotate.el")

--- a/NEWS.org
+++ b/NEWS.org
@@ -1,3 +1,7 @@
+- 2025-11-11 v2.4.5 cage ::
+
+  This version fixes a bug that prevented correct loading of the annotations database.
+
 - 2025-11-02 v2.4.4 cage ::
 
   This version informs the user when an error occurred while checking the existence of an annotated file.

--- a/annotate.el
+++ b/annotate.el
@@ -7,7 +7,7 @@
 ;; Maintainer: Bastian Bechtold <bastibe.dev@mailbox.org>, cage <cage-dev@twistfold.it>
 ;; URL: https://github.com/bastibe/annotate.el
 ;; Created: 2015-06-10
-;; Version: 2.4.4
+;; Version: 2.4.5
 ;; Package-Requires: ((emacs "27.1"))
 
 ;; This file is NOT part of GNU Emacs.
@@ -59,7 +59,7 @@
 ;;;###autoload
 (defgroup annotate nil
   "Annotate files without changing them."
-  :version "2.4.4"
+  :version "2.4.5"
   :group 'text)
 
 (defvar annotate-mode-map


### PR DESCRIPTION
Hi @bastibe !

This patch fixes a severe bug that prevented annotation database to be correctly loaded (some annotations would be missed).

Also i changed a function's name (and made it local) because the old name did not make any sense to me.

Because the bug is, in my opinion, severe I am going to merge this patch immediately.

Sorry for any inconvenience.

Bye!
C.